### PR TITLE
Add the ability to disable ticket transfers

### DIFF
--- a/app/Http/Controllers/Admin/SettingController.php
+++ b/app/Http/Controllers/Admin/SettingController.php
@@ -33,7 +33,7 @@ class SettingController extends Controller
     {
         $settings = Setting::whereHidden(false)->get();
         foreach ($settings as $setting) {
-            if ($request->has($setting->code)) {
+            if ($request->has($setting->code) || $setting->type === SettingType::stBoolean) {
                 $value = $request->input($setting->code);
                 if ($setting->type === SettingType::stBoolean) {
                     $value = (bool)$value;

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\TicketTransferRequest;
+use App\Models\Setting;
 use App\Models\Ticket;
 use Illuminate\Http\Request;
 
@@ -39,6 +40,9 @@ class TicketController extends Controller
 
     public function update(Request $request, Ticket $ticket)
     {
+        if(Setting::fetch('disable-ticket-transfers')){
+            return response()->redirectToRoute('tickets.show', $ticket->id)->with('errorMessage', 'Ticket transfers are disabled.');
+        }
         if ($request->has('generate')) {
             $ticket->generateTransferCode();
             return response()->redirectToRoute('tickets.show', $ticket->id)->with('successMessage', 'A new transfer code has been generated');
@@ -52,6 +56,9 @@ class TicketController extends Controller
 
     public function transfer(TicketTransferRequest $request)
     {
+        if(Setting::fetch('disable-ticket-transfers')){
+            return response()->redirectToRoute('tickets.index')->with('errorMessage', 'Ticket transfers are disabled.');
+        }
         $ticket = Ticket::whereTransferCode($request->input('code'))->first();
         $ticket->user()->associate($request->user());
         $ticket->transfer_code = null;

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -50,6 +50,12 @@ class SettingsSeeder extends Seeder
                 'name' => 'Discord Server ID',
                 'hidden' => true,
             ],
+            'disable-ticket-transfers' => (object)[
+                'name' => 'Disable Ticket Transfers',
+                'description' => 'Whether or not ticket transfers should be disabled',
+                'type' => SettingType::stBoolean,
+                'default' => false,
+            ],
         ];
         foreach ($settings as $code => $setting) {
             $this->updateSetting($code, $setting);

--- a/resources/views/tickets/index.blade.php
+++ b/resources/views/tickets/index.blade.php
@@ -18,7 +18,7 @@
     </p>
 
     <div class="row mb-2">
-        <div class="col-md-8 mb-4">
+        <div class="@if(App\Models\Setting::fetch('disable-ticket-transfers')) col-md-12 @else col-md-8 @endif mb-4">
             <div class="card">
                 <div class="card-header">
                     <h3 class="card-title">Your Tickets</h3>
@@ -76,6 +76,7 @@
                 ])
             </div>
         </div>
+        @if(!App\Models\Setting::fetch('disable-ticket-transfers'))
         <div class="col-md-4 mb-4">
             <div class="card">
                 <div class="card-header">
@@ -105,5 +106,6 @@
                 </form>
             </div>
         </div>
+        @endif
     </div>
 @endsection

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -18,7 +18,7 @@
     </div>
 
     <div class="row">
-        <div class="col-md-8 mb-4">
+        <div class="@if(App\Models\Setting::fetch('disable-ticket-transfers')) col-md-12 @else col-md-8 @endif mb-4">
             <div class="card">
                 <div class="card-body">
                     <div class="row">
@@ -78,6 +78,7 @@
                 </div>
             </div>
         </div>
+        @if(!App\Models\Setting::fetch('disable-ticket-transfers'))
         <div class="col-md-4 d-print-none">
             <div class="card">
                 <div class="card-header">
@@ -130,6 +131,7 @@
                 @endif
             </div>
         </div>
+        @endif
     </div>
 
 @endsection


### PR DESCRIPTION
In some cases, ticket providers already provide a way to transfer tickets and having one in the seat picker could be confusing. This aims to add a option to disable ticket transfers for those who wish to.

I discovered a small bug in the setting controller when updating boolean values - since if the boolean is false it is not included in the form data. I've done a fix of checking if the setting is included in the form data or is a boolean, whilst I don't think this is ideal I can't think of a much cleaner solution.