### PR TITLE
Add support for a Laravel Passport Social provider

### DIFF
--- a/app/Http/Controllers/Admin/SocialProviderController.php
+++ b/app/Http/Controllers/Admin/SocialProviderController.php
@@ -23,8 +23,12 @@ class SocialProviderController extends Controller
         $provider->client_secret = $request->input('client_secret');
         $provider->token = $request->input('token');
         $provider->enabled = (bool)$request->input('enabled');
+        $provider->host = $request->input('host');
         if ($provider->supports_auth) {
             $provider->auth_enabled = (bool)$request->input('auth_enabled');
+        }
+        if($provider->can_be_renamed){
+            $provider->name = $request->input('name');
         }
         $provider->save();
         return response()->redirectToRoute('admin.settings.index')->with('successMessage', "{$provider->name} has been updated");

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -30,6 +30,7 @@ use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use SocialiteProviders\Discord\DiscordExtendSocialite;
+use SocialiteProviders\LaravelPassport\LaravelPassportExtendSocialite;
 use SocialiteProviders\Manager\SocialiteWasCalled;
 use SocialiteProviders\Steam\SteamExtendSocialite;
 use SocialiteProviders\Twitch\TwitchExtendSocialite;
@@ -63,6 +64,7 @@ class EventServiceProvider extends ServiceProvider
             DiscordExtendSocialite::class . '@handle',
             SteamExtendSocialite::class . '@handle',
             TwitchExtendSocialite::class . '@handle',
+            LaravelPassportExtendSocialite::class . '@handle',
         ],
     ];
 

--- a/app/Services/SocialProviders/AbstractSocialProvider.php
+++ b/app/Services/SocialProviders/AbstractSocialProvider.php
@@ -21,6 +21,7 @@ abstract class AbstractSocialProvider implements SocialProviderContract
     protected string $socialiteProviderCode;
 
     protected bool $supportsAuth = false;
+    protected bool $canBeRenamed = false;
 
     public function __construct(protected ?SocialProvider $provider = null, protected ?string $redirectUrl = null)
     {
@@ -72,6 +73,7 @@ abstract class AbstractSocialProvider implements SocialProviderContract
         $provider->supports_auth = $this->supportsAuth;
         $provider->enabled = false;
         $provider->auth_enabled = false;
+        $provider->can_be_renamed = $this->canBeRenamed;
         $provider->save();
         return $provider;
     }

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "laravel/tinker": "^2.8",
         "ramsey/uuid": "^4.7",
         "socialiteproviders/discord": "^4.2",
+        "socialiteproviders/laravelpassport": "^4.3",
         "socialiteproviders/steam": "^4.2",
         "socialiteproviders/twitch": "^5.3",
         "spatie/eloquent-sortable": "^4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "963e2cb615de4a09803483ba001991f0",
+    "content-hash": "79d0305708bfb4834777ffe356883877",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4016,6 +4016,56 @@
                 "source": "https://github.com/socialiteproviders/providers"
             },
             "time": "2023-07-24T23:28:47+00:00"
+        },
+        {
+            "name": "socialiteproviders/laravelpassport",
+            "version": "4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/SocialiteProviders/Laravel-Passport.git",
+                "reference": "5ee785624a0fc5ee4b18922e1295a63729074285"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/SocialiteProviders/Laravel-Passport/zipball/5ee785624a0fc5ee4b18922e1295a63729074285",
+                "reference": "5ee785624a0fc5ee4b18922e1295a63729074285",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0",
+                "socialiteproviders/manager": "~4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "SocialiteProviders\\LaravelPassport\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "recca0120",
+                    "email": "recca0120@name.com"
+                }
+            ],
+            "description": "LaravelPassport OAuth2 Provider for Laravel Socialite",
+            "keywords": [
+                "laravel",
+                "oauth",
+                "passport",
+                "provider",
+                "socialite"
+            ],
+            "support": {
+                "docs": "https://socialiteproviders.com/laravelpassport",
+                "issues": "https://github.com/socialiteproviders/providers/issues",
+                "source": "https://github.com/socialiteproviders/providers"
+            },
+            "time": "2022-08-10T23:31:11+00:00"
         },
         {
             "name": "socialiteproviders/manager",

--- a/database/migrations/2024_01_08_234145_add_host_to_social_providers.php
+++ b/database/migrations/2024_01_08_234145_add_host_to_social_providers.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('social_providers', function (Blueprint $table) {
+            $table->longText('host')->nullable()->default(null)->after('token');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('social_providers', function (Blueprint $table) {
+            $table->dropColumn('host');
+        });
+    }
+};

--- a/database/migrations/2024_01_09_172838_add_can_be_renamed_to_social_providers.php
+++ b/database/migrations/2024_01_09_172838_add_can_be_renamed_to_social_providers.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('social_providers', function (Blueprint $table) {
+            $table->boolean('can_be_renamed')->default(false)->after('host');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('social_providers', function (Blueprint $table) {
+            $table->dropColumn('can_be_renamed');
+        });
+    }
+};

--- a/database/seeders/SocialProvidersSeeder.php
+++ b/database/seeders/SocialProvidersSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Services\SocialProviders\DiscordProvider;
+use App\Services\SocialProviders\LaravelPassportProvider;
 use App\Services\SocialProviders\SteamProvider;
 use App\Services\SocialProviders\TwitchProvider;
 use Illuminate\Database\Seeder;
@@ -18,6 +19,7 @@ class SocialProvidersSeeder extends Seeder
             DiscordProvider::class,
             SteamProvider::class,
             TwitchProvider::class,
+            LaravelPassportProvider::class
         ];
         foreach ($classes as $className) {
             $provider = new $className;

--- a/resources/views/admin/socialproviders/edit.blade.php
+++ b/resources/views/admin/socialproviders/edit.blade.php
@@ -30,6 +30,14 @@
                         @include('partials._providersconfig', [
                             'fieldName' => 'token',
                         ])
+                        @include('partials._providersconfig', [
+                            'fieldName' => 'host',
+                        ])
+                        @if($provider->can_be_renamed)
+                            @include('partials._providersconfig', [
+                                'fieldName' => 'name',
+                            ])
+                        @endif
                         <div class="mb-3">
                             <label class="form-check form-switch">
                                 <input type="checkbox" class="form-check-input" name="enabled" value="1"


### PR DESCRIPTION
This adds a basic implementation of the Laravel Passport socialite provider. I've added a basic functionality for it to be renamed via the settings panel so it doesn't display as "Laravel Passport" which is not particularly end-user friendly.

Once it is easier to add more settings for a social provider then we'll be able to add more options to make it easier for others to use this provider however currently it's setup in the most generic way that works for us.