### PR TITLE
Add support to assign a seat to a specific clan

### DIFF
--- a/app/Http/Controllers/Admin/SeatController.php
+++ b/app/Http/Controllers/Admin/SeatController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\SeatUpdateRequest;
+use App\Models\Clan;
 use App\Models\Event;
 use App\Models\Seat;
 use App\Models\SeatingPlan;
@@ -40,6 +41,15 @@ class SeatController extends Controller
         $seat->description = $request->input('description');
         $seat->class = $request->input('class');
         $seat->disabled = (bool)$request->input('disabled', false);
+        if($request->has('clan_id')){
+            $clanId = $request->input('clan_id');
+            $clan = Clan::whereId($clanId)->first();
+            if($clan && $seat->clan != $clan){
+                $seat->clan()->associate($clan);
+            } else if(!$clan){
+                $seat->clan()->disassociate();
+            }
+        }
         $seat->save();
     }
 
@@ -48,7 +58,7 @@ class SeatController extends Controller
         return view('admin.seats.show', [
             'event' => $event,
             'plan' => $seatingplan,
-            'seat' => $seat,
+            'seat' => $seat
         ]);
     }
 
@@ -58,6 +68,7 @@ class SeatController extends Controller
             'event' => $event,
             'plan' => $seatingplan,
             'seat' => $seat,
+            'clans' => Clan::all()
         ]);
     }
 

--- a/app/Http/Controllers/SeatingPlanController.php
+++ b/app/Http/Controllers/SeatingPlanController.php
@@ -96,11 +96,17 @@ class SeatingPlanController extends Controller
             $seats[$plan->id] = $plan->getData();
         }
 
+        $myClans = [];
+        foreach($request->user()->clanMemberships as $clanMembership){
+            $myClans[] = $clanMembership->clan->code;
+        }
+
         $params = [
             'allTickets' => $allTickets,
             'event' => $event,
             'seats' => $seats,
             'mySeats' => $mySeats,
+            'myClans' => $myClans,
             'clanSeats' => $clanSeats,
             'responsibleSeats' => $responsibleSeats,
             'responsibleTickets' => $responsibleTickets,

--- a/app/Models/Seat.php
+++ b/app/Models/Seat.php
@@ -24,6 +24,11 @@ class Seat extends Model
         return $this->belongsTo(SeatingPlan::class, 'seating_plan_id');
     }
 
+    public function clan(): BelongsTo
+    {
+        return $this->belongsTo(Clan::class);
+    }
+
     public function canPick(?User $user = null): bool
     {
         if ($this->disabled) {
@@ -37,6 +42,9 @@ class Seat extends Model
         }
         $tickets = $user->getPickableTickets($this->plan->event);
         if (!$tickets) {
+            return false;
+        }
+        if($this->clan != null && !$this->clan->isMember($user)){
             return false;
         }
         if ($this->ticket) {

--- a/app/Models/SeatingPlan.php
+++ b/app/Models/SeatingPlan.php
@@ -69,6 +69,9 @@ class SeatingPlan extends Model implements Sortable
             foreach ($seat->ticket->user->clanMemberships ?? [] as $clanMembership) {
                 $clans[] = $clanMembership->clan->name;
             }
+            if($seat->clan && !in_array($seat->clan->name, $clans)){
+                $clans[] = $seat->clan->name;
+            }
             $seatData = (object)[
                 'id' => $seat->id,
                 'x' => $seat->x,
@@ -85,6 +88,8 @@ class SeatingPlan extends Model implements Sortable
                 'ticketId' => $seat->ticket->id ?? null,
                 'clans' => $clans,
                 'canPick' => $seat->canPick(),
+                'clan' => $seat->clan->name ?? null,
+                'clanCode' => $seat->clan->code ?? null
             ];
             $data->push($seatData);
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -122,9 +122,6 @@ class User extends Authenticatable
         return $this->hasMany(ClanMembership::class);
     }
 
-    public function inClan(string $clanCode): bool {
-        return Clan::whereCode($clanCode)->first()->isMember($this);
-    }
 
     protected function toStringName(): string
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -122,6 +122,10 @@ class User extends Authenticatable
         return $this->hasMany(ClanMembership::class);
     }
 
+    public function inClan(string $clanCode): bool {
+        return Clan::whereCode($clanCode)->first()->isMember($this);
+    }
+
     protected function toStringName(): string
     {
         return $this->nickname;

--- a/database/migrations/2024_01_12_160710_add_assigned_clan_to_seats.php
+++ b/database/migrations/2024_01_12_160710_add_assigned_clan_to_seats.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('seats', function (Blueprint $table) {
+            $table->foreignId('clan_id')->nullable()->after('disabled')->constrained()->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('seats', function (Blueprint $table) {
+           $table->dropColumn('clan_id');
+           $table->dropForeign(['clan_id']);
+        });
+    }
+};

--- a/resources/views/admin/seats/_form.blade.php
+++ b/resources/views/admin/seats/_form.blade.php
@@ -81,6 +81,22 @@
         </div>
     </div>
     <div class="mb-3">
+        <label class="form-label">Assigned Clan</label>
+        <div>
+            <select class="form-select @error('clan_id') is-invalid @enderror" name="clan_id">
+                <option value=""></option>
+                @foreach($clans as $clan)
+                <option value="{{ $clan->id }}"
+                        @if(old('clan_id', $seat->clan_id) == $clan->id) selected @endif>{{ $clan->name }}</option>
+                @endforeach
+            </select>
+            <small class="form-hint">An optional Clan to assign to this seat.</small>
+            @error('clan_id')
+            <p class="invalid-feedback">{{ $message }}</p>
+            @enderror
+        </div>
+    </div>
+    <div class="mb-3">
         <label class="form-check form-switch">
             <input type="checkbox" class="form-check-input" name="disabled" value="1"
                    @if(old('disabled', $seat->disabled)) checked @endif>

--- a/resources/views/admin/seats/show.blade.php
+++ b/resources/views/admin/seats/show.blade.php
@@ -72,6 +72,16 @@
                                 @endif
                             </div>
                         </div>
+                        <div class="datagrid-item">
+                            <div class="datagrid-title">Assigned Clan</div>
+                            <div class="datagrid-content">
+                                @if($seat->clan)
+                                    <a href="{{ route('admin.clans.show', [$seat->clan->code]) }}">{{ $seat->clan->name}}</a>
+                                @else
+                                    <span class="text-muted">None</span>
+                                @endif
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div class="card-footer align-content-end d-flex btn-list">

--- a/resources/views/seatingplans/_plan.blade.php
+++ b/resources/views/seatingplans/_plan.blade.php
@@ -23,6 +23,16 @@
                     $canPick = false;
                     $name = 'Occupied';
                 }
+                if($seat->clan){
+                    if(Auth::user()->inClan($seat->clanCode)){
+                        $class = 'seat-clan';
+                        $name = 'Available';
+                    } else {
+                        $canPick = false;
+                        $class = 'taken';
+                        $name = 'Not Available';
+                    }
+                }
                 if ($seat->nickname) {
                     $name = $seat->nickname;
                 }

--- a/resources/views/seatingplans/_plan.blade.php
+++ b/resources/views/seatingplans/_plan.blade.php
@@ -24,7 +24,7 @@
                     $name = 'Occupied';
                 }
                 if($seat->clan){
-                    if(Auth::user()->inClan($seat->clanCode)){
+                    if(in_array($seat->clanCode, $myClans)){
                         $class = 'seat-clan';
                         $name = 'Available';
                     } else {


### PR DESCRIPTION
Adds the ability to assign a seat to a specific clan, preventing non clan members from picking those seats. Useful for when a clan wants to book out specific rows etc.

In the future if clans gain individual colours, it would be good to outline their seats with their colour. 