### PR TITLE
Manager Role

### DIFF
--- a/app/Http/Controllers/SeatingPlanController.php
+++ b/app/Http/Controllers/SeatingPlanController.php
@@ -12,7 +12,7 @@ class SeatingPlanController extends Controller
     public function index(Request $request)
     {
         $query = Event::query();
-        if (!$request->user()->hasRole('admin')) {
+        if (!$request->user()->hasAnyRole(['admin','manager'])) {
             $query = $query->whereDraft(false);
         }
         $events = $query->orderBy('starts_at', 'DESC')->with('seatingPlans')->paginate();

--- a/app/Models/SeatingPlan.php
+++ b/app/Models/SeatingPlan.php
@@ -81,6 +81,7 @@ class SeatingPlan extends Model implements Sortable
                 'description' => $seat->description,
                 'nickname' => $seat->ticket->user->nickname ?? null,
                 'original_email' => $seat->ticket->original_email ?? null,
+                'external_id' => $seat->ticket->external_id ?? null,
                 'ticket' => $seat->ticket->type->name ?? null,
                 'ticketId' => $seat->ticket->id ?? null,
                 'clans' => $clans,

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -60,6 +60,18 @@ class User extends Authenticatable
         return (bool)$this->roles()->whereCode($role)->count();
     }
 
+    public function hasAnyRole(array $roles): bool
+    {
+        foreach ($roles as $role) {
+            if ($role instanceof Role) {
+                $role = $role->code;
+            }
+            if ($this->roles()->whereCode($role)->count())
+                return true;
+        }
+        return false;
+    }
+
     public function roles(): BelongsToMany
     {
         return $this->belongsToMany(Role::class);

--- a/app/Policies/EventPolicy.php
+++ b/app/Policies/EventPolicy.php
@@ -13,6 +13,6 @@ class EventPolicy
         if (!$event->draft) {
             return true;
         }
-        return $user->hasRole('admin');
+        return $user->hasAnyRole(['admin', 'manager']);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -28,5 +28,11 @@ class AuthServiceProvider extends ServiceProvider
         Gate::define('viewPulse', function (User $user) {
             return $user->hasRole('admin');
         });
+        Gate::define('manager', function (User $user) {
+            return $user->hasRole('manager');
+        });
+        Gate::define('anyPrivilegedRole', function (User $user) {
+            return $user->hasRole('manager') || $user->hasRole('admin');
+        });
     }
 }

--- a/database/seeders/RolesSeeder.php
+++ b/database/seeders/RolesSeeder.php
@@ -15,6 +15,7 @@ class RolesSeeder extends Seeder
     {
         $roles = [
             'admin' => 'Admin',
+            'manager' => 'Manager'
         ];
 
         foreach ($roles as $code => $name) {

--- a/resources/views/admin/clans/index.blade.php
+++ b/resources/views/admin/clans/index.blade.php
@@ -32,11 +32,12 @@
                         'name' => 'Code',
                         'property' => 'code',
                     ])
-                    @include('partials._searchtextfield', [
-                        'name' => 'Invite Code',
-                        'property' => 'invite_code',
-                    ])
-
+                    @can('admin')
+                        @include('partials._searchtextfield', [
+                            'name' => 'Invite Code',
+                            'property' => 'invite_code',
+                        ])
+                    @endcan
                 </div>
                 <div class="card-footer d-flex">
                     <button class="btn btn-primary ms-auto" type="submit">Search</button>
@@ -74,12 +75,14 @@
                                     'field' => 'members_count',
                                 ])
                             </th>
-                            <th>
-                                @include('partials._sortheader', [
-                                    'title' => 'Invitation Code',
-                                    'field' => 'invite_code',
-                                ])
-                            </th>
+                            @can('admin')
+                                <th>
+                                    @include('partials._sortheader', [
+                                        'title' => 'Invitation Code',
+                                        'field' => 'invite_code',
+                                    ])
+                                </th>
+                            @endcan
                             <th>
                                 @include('partials._sortheader', [
                                     'title' => 'Created',
@@ -100,7 +103,9 @@
                                 </td>
                                 <td>{{ $clan->code }}</td>
                                 <td>{{ $clan->members_count }}</td>
-                                <td><span class="user-select-all">{{ $clan->invite_code }}</span></td>
+                                @can('admin')
+                                    <td><span class="user-select-all">{{ $clan->invite_code }}</span></td>
+                                @endcan
                                 <td>
                                         <span title="{{ $clan->created_at->format('Y-m-d H:i:s') }}">
                                             {{ $clan->created_at->diffForHumans() }}

--- a/resources/views/admin/clans/show.blade.php
+++ b/resources/views/admin/clans/show.blade.php
@@ -30,11 +30,13 @@
                             <div class="datagrid-title">Code</div>
                             <div class="datagrid-content">{{ $clan->code }}</div>
                         </div>
-                        <div class="datagrid-item">
-                            <div class="datagrid-title">Invite Code</div>
-                            <div class="datagrid-content"><span class="user-select-all">{{ $clan->invite_code }}</span>
+                        @can('admin')
+                            <div class="datagrid-item">
+                                <div class="datagrid-title">Invite Code</div>
+                                <div class="datagrid-content"><span class="user-select-all">{{ $clan->invite_code }}</span>
+                                </div>
                             </div>
-                        </div>
+                        @endcan
                         <div class="datagrid-item">
                             <div class="datagrid-title">Created</div>
                             <div class="datagrid-content">
@@ -45,21 +47,23 @@
                         </div>
                     </div>
                 </div>
-                <div class="card-footer align-content-end d-flex btn-list">
-                    <a href="{{ route('admin.clans.delete', $clan->code) }}" class="btn btn-outline-danger">
-                        <i class="icon ti ti-trash"></i>
-                        Delete
-                    </a>
-                    <a href="{{ route('admin.clans.regenerate', $clan->code) }}"
-                       class="btn btn-primary-outline ms-auto">
-                        <i class="icon ti ti-refresh"></i>
-                        Generate New Invite Code
-                    </a>
-                    <a href="{{ route('admin.clans.edit', $clan->code) }}" class="btn btn-primary">
-                        <i class="icon ti ti-edit"></i>
-                        Edit
-                    </a>
-                </div>
+                @can('admin')
+                    <div class="card-footer align-content-end d-flex btn-list">
+                        <a href="{{ route('admin.clans.delete', $clan->code) }}" class="btn btn-outline-danger">
+                            <i class="icon ti ti-trash"></i>
+                            Delete
+                        </a>
+                        <a href="{{ route('admin.clans.regenerate', $clan->code) }}"
+                           class="btn btn-primary-outline ms-auto">
+                            <i class="icon ti ti-refresh"></i>
+                            Generate New Invite Code
+                        </a>
+                        <a href="{{ route('admin.clans.edit', $clan->code) }}" class="btn btn-primary">
+                            <i class="icon ti ti-edit"></i>
+                            Edit
+                        </a>
+                    </div>
+                @endcan
             </div>
         </div>
     </div>
@@ -113,18 +117,20 @@
                                         {{ $member->created_at->diffForHumans() }}
                                     </span>
                                 </td>
-                                <td class="btn-list">
-                                    <a class="btn btn-outline-primary ms-auto"
-                                       href="{{ route('admin.clans.members.edit', [$clan->code, $member->id]) }}">
-                                        <i class="icon ti ti-edit"></i>
-                                        Edit
-                                    </a>
-                                    <a class="btn btn-outline-danger @if(!$member->canDelete()) disabled @endif"
-                                       @if ($member->canDelete()) href="{{ route('admin.clans.members.delete', [$clan->code, $member->id]) }}" @endif>
-                                        <i class="icon ti ti-trash"></i>
-                                        Remove
-                                    </a>
-                                </td>
+                                @can('admin')
+                                    <td class="btn-list">
+                                        <a class="btn btn-outline-primary ms-auto"
+                                           href="{{ route('admin.clans.members.edit', [$clan->code, $member->id]) }}">
+                                            <i class="icon ti ti-edit"></i>
+                                            Edit
+                                        </a>
+                                        <a class="btn btn-outline-danger @if(!$member->canDelete()) disabled @endif"
+                                           @if ($member->canDelete()) href="{{ route('admin.clans.members.delete', [$clan->code, $member->id]) }}" @endif>
+                                            <i class="icon ti ti-trash"></i>
+                                            Remove
+                                        </a>
+                                    </td>
+                                @endcan
                             </tr>
 
                         @empty

--- a/resources/views/admin/events/index.blade.php
+++ b/resources/views/admin/events/index.blade.php
@@ -13,14 +13,16 @@
         <div class="col page-header mt-2">
             <h1>Events</h1>
         </div>
-        <div class="col-auto ms-auto d-print-none">
-            <div class="btn-list">
-                <a href="{{ route('admin.events.create') }}" class="btn btn-primary d-inline-block">
-                    <i class="icon ti ti-plus"></i>
-                    Create Event
-                </a>
+        @can('admin')
+            <div class="col-auto ms-auto d-print-none">
+                <div class="btn-list">
+                    <a href="{{ route('admin.events.create') }}" class="btn btn-primary d-inline-block">
+                        <i class="icon ti ti-plus"></i>
+                        Create Event
+                    </a>
+                </div>
             </div>
-        </div>
+        @endcan
     </div>
     <div class="row">
         <div class="col-md-12 col-lg-3 mb-4">

--- a/resources/views/admin/events/seats.blade.php
+++ b/resources/views/admin/events/seats.blade.php
@@ -14,7 +14,11 @@
 
     @if ($currentTicket)
         <p>
-            Choose a seat for <strong>{{ $currentTicket->user->nickname ?? $currentTicket->original_email }}</strong>.
+            @can('admin')
+                Choose a seat for <strong>{{ $currentTicket->user->nickname ?? $currentTicket->original_email }}</strong>.
+            @else
+                Choose a seat for <strong>{{ $currentTicket->user->nickname ?? $currentTicket->external_id }}</strong>.
+            @endcan
         </p>
     @else
         <p>
@@ -27,7 +31,11 @@
             @if($currentTicket)
                 <div class="card mb-4">
                     <div class="card-body">
-                        <h3 class="card-title">{{ $currentTicket->user->nickname ?? $currentTicket->original_email }}</h3>
+                        @can('admin')
+                            <h3 class="card-title">{{ $currentTicket->user->nickname ?? $currentTicket->original_email }}</h3>
+                        @else
+                            <h3 class="card-title">{{ $currentTicket->user->nickname ?? $currentTicket->external_id }}</h3>
+                        @endcan
                         @if($currentTicket->user && $currentTicket->user->clanMemberships)
                             <p class="card-subtitle">
 
@@ -86,7 +94,12 @@
                             @foreach($tickets as $ticket)
                                 <li class="my-1">
                                     <a href="{{ route('admin.events.seats', ['event' => $event, 'ticket_id' => $ticket->id]) }}">
-                                        {{ $ticket->user->nickname ?? $ticket->original_email }}</a>
+                                        @can('admin')
+                                            {{ $ticket->user->nickname ?? $ticket->original_email }}
+                                        @else
+                                            {{ $ticket->user->nickname ?? $ticket->external_id }}
+                                        @endcan
+                                    </a>
                                     <span class="badge-list">
                                     @if ($ticket->user)
                                         @foreach($ticket->user->clanMemberships as $clanMember)
@@ -149,7 +162,10 @@
                                             }
                                             if ($seat->ticket) {
                                                 $class = 'taken';
-                                                $name = $seat->original_email;
+                                                if(Request::user()->hasRole('admin'))
+                                                    $name = $seat->original_email;
+                                                else
+                                                    $name = $seat->external_id;
                                             }
                                             if ($seat->nickname) {
                                                 $name = $seat->nickname;

--- a/resources/views/admin/events/show.blade.php
+++ b/resources/views/admin/events/show.blade.php
@@ -113,256 +113,267 @@
 
                     </div>
                 </div>
-                <div class="card-footer align-content-end d-flex btn-list">
-                    <a href="{{ route('admin.events.delete', $event->code) }}" class="btn btn-outline-danger">
-                        <i class="icon ti ti-trash"></i>
-                        Delete
-                    </a>
+                @can('admin')
+                    <div class="card-footer align-content-end d-flex btn-list">
+                        <a href="{{ route('admin.events.delete', $event->code) }}" class="btn btn-outline-danger">
+                            <i class="icon ti ti-trash"></i>
+                            Delete
+                        </a>
 
-                    <a href="{{ route('admin.events.export', $event->code) }}" class="btn btn-primary-outline ms-auto">
-                        <i class="icon ti ti-table-export"></i>
-                        Export Ticket List
-                    </a>
-                    <a href="{{ route('admin.tickets.index', ['event' => $event->code]) }}"
-                       class="btn btn-primary-outline">
-                        <i class="icon ti ti-ticket"></i>
-                        Tickets
-                        ({{ $event->tickets()->count() }})
-                    </a>
-                    <a href="{{ route('admin.tickets.create', ['event' => $event->code]) }}"
-                       class="btn btn-primary-outline">
-                        <i class="icon ti ti-plus"></i>
-                        Add Ticket
-                    </a>
-                    <a href="{{ route('admin.events.edit', $event->code) }}" class="btn btn-primary">
-                        <i class="icon ti ti-edit"></i>
-                        Edit
-                    </a>
-                </div>
+                        <a href="{{ route('admin.events.export', $event->code) }}" class="btn btn-primary-outline ms-auto">
+                            <i class="icon ti ti-table-export"></i>
+                            Export Ticket List
+                        </a>
+                        <a href="{{ route('admin.tickets.index', ['event' => $event->code]) }}"
+                           class="btn btn-primary-outline">
+                            <i class="icon ti ti-ticket"></i>
+                            Tickets
+                            ({{ $event->tickets()->count() }})
+                        </a>
+                        <a href="{{ route('admin.tickets.create', ['event' => $event->code]) }}"
+                           class="btn btn-primary-outline">
+                            <i class="icon ti ti-plus"></i>
+                            Add Ticket
+                        </a>
+                        <a href="{{ route('admin.events.edit', $event->code) }}" class="btn btn-primary">
+                            <i class="icon ti ti-edit"></i>
+                            Edit
+                        </a>
+                    </div>
+                @else
+                    <div class="card-footer align-content-end d-flex btn-list">
+                        <a href="{{ route('admin.events.seats', $event->code) }}" class="btn btn-primary-outline">
+                            <i class="icon ti ti-armchair"></i>
+                            Manage Seating
+                        </a>
+                    </div>
+                @endcan
             </div>
         </div>
     </div>
 
-    <div class="row align-items-center">
-        <div class="col page-header mt-2">
-            <h2>Seating Plans</h2>
-        </div>
-        <div class="col-auto ms-auto d-print-none">
-            <div class="btn-list">
-                <a href="{{ route('admin.events.seats', $event->code) }}" class="btn btn-primary-outline">
-                    <i class="icon ti ti-armchair"></i>
-                    Manage Seating
-                </a>
-                <a href="{{ route('admin.events.seatingplans.create', $event->code) }}"
-                   class="btn btn-primary d-inline-block">
-                    <i class="icon ti ti-plus"></i>
-                    Add Seating Plan
-                </a>
+    @can('admin')
+        <div class="row align-items-center">
+            <div class="col page-header mt-2">
+                <h2>Seating Plans</h2>
             </div>
-        </div>
-    </div>
-
-    <div class="row mb-4">
-        <div class="col-12">
-            <div class="card">
-                <div class="table-responsive">
-                    <table class="table table-vcenter card-table">
-                        <thead>
-                        <tr>
-                            <th>ID</th>
-                            <th>Order</th>
-                            <th>Name</th>
-                            <th>Code</th>
-                            <th>Seats</th>
-                            <th>Revision</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        @forelse($seatingPlans as $plan)
-                            <tr>
-                                <td class="text-muted">{{ $plan->id }}</td>
-                                <td>
-                                    <a href="{{ route('admin.events.seatingplans.down', [$event->code, $plan->id]) }}"
-                                       class="text-decoration-none text-muted">
-                                        <i class="icon ti ti-caret-down-filled"></i>
-                                    </a>
-                                    {{ $plan->order }}
-                                    <a href="{{ route('admin.events.seatingplans.up', [$event->code, $plan->id]) }}"
-                                       class="text-decoration-none text-muted">
-                                        <i class="icon ti ti-caret-up-filled"></i>
-                                    </a>
-                                </td>
-                                <td>
-                                    <a href="{{ route('admin.events.seatingplans.show', [$event->code, $plan->id]) }}">{{ $plan->name }}</a>
-                                </td>
-                                <td>{{ $plan->code }}</td>
-                                <td>{{ $plan->seats_count }}</td>
-                                <td>{{ $plan->revision }}</td>
-                            </tr>
-
-                        @empty
-                            <tr>
-                                <td colspan="6" class="text-center p-4">
-                                    <p>There are no seating plans</p>
-                                </td>
-                            </tr>
-                        @endforelse
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="row align-items-center">
-        <div class="col page-header mt-2">
-            <h2>Ticket Types</h2>
-        </div>
-        <div class="col-auto ms-auto d-print-none">
-            <div class="btn-list">
-                <a href="{{ route('admin.events.tickettypes.create', $event->code) }}"
-                   class="btn btn-primary d-inline-block">
-                    <i class="icon ti ti-plus"></i>
-                    Add Ticket Type
-                </a>
-            </div>
-        </div>
-    </div>
-
-    <p>
-        This is where you can define the different types of tickets you have, and whether they are able to pick seats or
-        not. This
-        also allows you to link them to ticket types from your ticket provider.
-    </p>
-
-    <div class="row mb-4">
-        <div class="col-12">
-            <div class="card">
-                <div class="table-responsive">
-                    <table class="table table-vcenter card-table">
-                        <thead>
-                        <tr>
-                            <th>ID</th>
-                            <th>Name</th>
-                            <th>Has Seats</th>
-                            <th>Discord Role</th>
-                            <th>Tickets</th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        @forelse($ticketTypes as $type)
-                            <tr>
-                                <td class="text-muted">{{ $type->id }}</td>
-                                <td>
-                                    <a href="{{ route('admin.events.tickettypes.show', [$event->code, $type->id]) }}">{{ $type->name }}</a>
-                                </td>
-                                <td>
-                                    @if($type->has_seat)
-                                        <span class="status status-green">Yes</span>
-                                    @else
-                                        <span class="status status-red">No</span>
-                                    @endif
-                                </td>
-                                <td>
-                                    @if($type->discord_role_id)
-                                        {{ $type->discord_role_name ?? $type->discord_role_id }}
-                                    @else
-                                        <span class="text-muted">None</span>
-                                    @endif
-                                </td>
-                                <td>
-                                    <a href="{{ route('admin.tickets.index', ['ticket_type_id' => $type->id]) }}">{{ $type->tickets_count }}</a>
-                                </td>
-                            </tr>
-
-                        @empty
-                            <tr>
-                                <td colspan="4" class="text-center p-4">
-                                    <p>There are no ticket types</p>
-                                </td>
-                            </tr>
-                        @endforelse
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <div class="row align-items-center">
-        <div class="col page-header mt-2">
-            <h2>Ticket Provider Mappings</h2>
-        </div>
-        <div class="col-auto ms-auto d-print-none">
-            <div class="btn-list">
-                @if($event->getAvailableEventMappings())
-                    <a href="{{ route('admin.events.mappings.create', $event->code) }}"
+            <div class="col-auto ms-auto d-print-none">
+                <div class="btn-list">
+                    <a href="{{ route('admin.events.seats', $event->code) }}" class="btn btn-primary-outline">
+                        <i class="icon ti ti-armchair"></i>
+                        Manage Seating
+                    </a>
+                    <a href="{{ route('admin.events.seatingplans.create', $event->code) }}"
                        class="btn btn-primary d-inline-block">
                         <i class="icon ti ti-plus"></i>
-                        Add Mapping
+                        Add Seating Plan
                     </a>
-                @endif
-            </div>
-        </div>
-    </div>
-
-    <p>
-        This mapping allows us to link tickets from a ticket provider to this event.
-    </p>
-
-    <div class="row mb-4">
-        <div class="col-12">
-            <div class="card">
-                <div class="table-responsive">
-                    <table class="table table-vcenter card-table">
-                        <thead>
-                        <tr>
-                            <th>ID</th>
-                            <th>Provider</th>
-                            <th>External ID</th>
-                            <th>External Name</th>
-                            <th></th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        @forelse($event->mappings as $map)
-                            <tr>
-                                <td class="text-muted">{{ $map->id }}</td>
-                                <td>{{ $map->provider->name }}</td>
-                                <td>{{ $map->external_id }}</td>
-                                <td>
-                                    @if($map->name)
-                                        {{ $map->name }}
-                                    @else
-                                        <span class="text-muted">None</span>
-                                    @endif
-                                </td>
-                                <td class="btn-list">
-                                    <a class="btn btn-outline-primary ms-auto"
-                                       href="{{ route('admin.events.mappings.edit', [$event->code, $map->id]) }}">
-                                        <i class="icon ti ti-edit"></i>
-                                        Edit
-                                    </a>
-                                    <a class="btn btn-outline-danger"
-                                       href="{{ route('admin.events.mappings.delete', [$event->code, $map->id]) }}">
-                                        <i class="icon ti ti-trash"></i>
-                                        Delete
-                                    </a>
-                                </td>
-                            </tr>
-
-                        @empty
-                            <tr>
-                                <td colspan="4" class="text-center p-4">
-                                    <p>There are no ticket provider mappings</p>
-                                </td>
-                            </tr>
-                        @endforelse
-                        </tbody>
-                    </table>
                 </div>
             </div>
         </div>
-    </div>
+
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="table-responsive">
+                        <table class="table table-vcenter card-table">
+                            <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Order</th>
+                                <th>Name</th>
+                                <th>Code</th>
+                                <th>Seats</th>
+                                <th>Revision</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @forelse($seatingPlans as $plan)
+                                <tr>
+                                    <td class="text-muted">{{ $plan->id }}</td>
+                                    <td>
+                                        <a href="{{ route('admin.events.seatingplans.down', [$event->code, $plan->id]) }}"
+                                           class="text-decoration-none text-muted">
+                                            <i class="icon ti ti-caret-down-filled"></i>
+                                        </a>
+                                        {{ $plan->order }}
+                                        <a href="{{ route('admin.events.seatingplans.up', [$event->code, $plan->id]) }}"
+                                           class="text-decoration-none text-muted">
+                                            <i class="icon ti ti-caret-up-filled"></i>
+                                        </a>
+                                    </td>
+                                    <td>
+                                        <a href="{{ route('admin.events.seatingplans.show', [$event->code, $plan->id]) }}">{{ $plan->name }}</a>
+                                    </td>
+                                    <td>{{ $plan->code }}</td>
+                                    <td>{{ $plan->seats_count }}</td>
+                                    <td>{{ $plan->revision }}</td>
+                                </tr>
+
+                            @empty
+                                <tr>
+                                    <td colspan="6" class="text-center p-4">
+                                        <p>There are no seating plans</p>
+                                    </td>
+                                </tr>
+                            @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row align-items-center">
+            <div class="col page-header mt-2">
+                <h2>Ticket Types</h2>
+            </div>
+            <div class="col-auto ms-auto d-print-none">
+                <div class="btn-list">
+                    <a href="{{ route('admin.events.tickettypes.create', $event->code) }}"
+                       class="btn btn-primary d-inline-block">
+                        <i class="icon ti ti-plus"></i>
+                        Add Ticket Type
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <p>
+            This is where you can define the different types of tickets you have, and whether they are able to pick seats or
+            not. This
+            also allows you to link them to ticket types from your ticket provider.
+        </p>
+
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="table-responsive">
+                        <table class="table table-vcenter card-table">
+                            <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Name</th>
+                                <th>Has Seats</th>
+                                <th>Discord Role</th>
+                                <th>Tickets</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @forelse($ticketTypes as $type)
+                                <tr>
+                                    <td class="text-muted">{{ $type->id }}</td>
+                                    <td>
+                                        <a href="{{ route('admin.events.tickettypes.show', [$event->code, $type->id]) }}">{{ $type->name }}</a>
+                                    </td>
+                                    <td>
+                                        @if($type->has_seat)
+                                            <span class="status status-green">Yes</span>
+                                        @else
+                                            <span class="status status-red">No</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        @if($type->discord_role_id)
+                                            {{ $type->discord_role_name ?? $type->discord_role_id }}
+                                        @else
+                                            <span class="text-muted">None</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        <a href="{{ route('admin.tickets.index', ['ticket_type_id' => $type->id]) }}">{{ $type->tickets_count }}</a>
+                                    </td>
+                                </tr>
+
+                            @empty
+                                <tr>
+                                    <td colspan="4" class="text-center p-4">
+                                        <p>There are no ticket types</p>
+                                    </td>
+                                </tr>
+                            @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row align-items-center">
+            <div class="col page-header mt-2">
+                <h2>Ticket Provider Mappings</h2>
+            </div>
+            <div class="col-auto ms-auto d-print-none">
+                <div class="btn-list">
+                    @if($event->getAvailableEventMappings())
+                        <a href="{{ route('admin.events.mappings.create', $event->code) }}"
+                           class="btn btn-primary d-inline-block">
+                            <i class="icon ti ti-plus"></i>
+                            Add Mapping
+                        </a>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        <p>
+            This mapping allows us to link tickets from a ticket provider to this event.
+        </p>
+
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="table-responsive">
+                        <table class="table table-vcenter card-table">
+                            <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Provider</th>
+                                <th>External ID</th>
+                                <th>External Name</th>
+                                <th></th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @forelse($event->mappings as $map)
+                                <tr>
+                                    <td class="text-muted">{{ $map->id }}</td>
+                                    <td>{{ $map->provider->name }}</td>
+                                    <td>{{ $map->external_id }}</td>
+                                    <td>
+                                        @if($map->name)
+                                            {{ $map->name }}
+                                        @else
+                                            <span class="text-muted">None</span>
+                                        @endif
+                                    </td>
+                                    <td class="btn-list">
+                                        <a class="btn btn-outline-primary ms-auto"
+                                           href="{{ route('admin.events.mappings.edit', [$event->code, $map->id]) }}">
+                                            <i class="icon ti ti-edit"></i>
+                                            Edit
+                                        </a>
+                                        <a class="btn btn-outline-danger"
+                                           href="{{ route('admin.events.mappings.delete', [$event->code, $map->id]) }}">
+                                            <i class="icon ti ti-trash"></i>
+                                            Delete
+                                        </a>
+                                    </td>
+                                </tr>
+
+                            @empty
+                                <tr>
+                                    <td colspan="4" class="text-center p-4">
+                                        <p>There are no ticket provider mappings</p>
+                                    </td>
+                                </tr>
+                            @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endcan
 
 @endsection

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -94,8 +94,13 @@
                                         {{ $user->nickname }}
                                     </a>
                                 </td>
-                                <td>{{ $user->name }}</td>
-                                <td>{{ $user->primaryEmail->email ?? 'None' }}</td>
+                                @can('admin')
+                                    <td>{{ $user->name }}</td>
+                                    <td>{{ $user->primaryEmail->email ?? 'None' }}</td>
+                                @else
+                                    <td>{{ explode(" ", $user->name)[0] }}</td>
+                                    <td>****</td>
+                                @endcan
                                 <td>
                                     @if($user->last_login)
                                         <span title="{{ $user->last_login->format('Y-m-d H:i:s') }}">

--- a/resources/views/admin/users/show.blade.php
+++ b/resources/views/admin/users/show.blade.php
@@ -34,25 +34,33 @@
                         </div>
                         <div class="datagrid-item">
                             <div class="datagrid-title">Name</div>
-                            <div class="datagrid-content">{{ $user->name }}</div>
+                            @can('admin')
+                                <div class="datagrid-content">{{ $user->name }}</div>
+                            @else
+                                <div class="datagrid-content">{{ explode(" ", $user->name)[0] }}</div>
+                            @endcan
                         </div>
                         <div class="datagrid-item">
                             <div class="datagrid-title">Primary Email</div>
                             <div class="datagrid-content">
-                                @if($user->primaryEmail)
-                                    <a href="mailto:{{ $user->primaryEmail->email }}">{{ $user->primaryEmail->email }}</a>
+                                @can('admin')
+                                    @if($user->primaryEmail)
+                                        <a href="mailto:{{ $user->primaryEmail->email }}">{{ $user->primaryEmail->email }}</a>
+                                    @else
+                                        <span class="text-muted">None</span>
+                                    @endif
                                 @else
-                                    <span class="text-muted">None</span>
-                                @endif
+                                    <td>****</td>
+                                @endcan
                             </div>
                         </div>
                         <div class="datagrid-item">
                             <div class="datagrid-title">Roles</div>
                             <div class="datagrid-content">
                                 @forelse($user->roles as $role)
-                                    <span class="badge bg-primary text-primary-fg">{{ $role->name }}
-                                        @empty
-                                            <span class="text-muted">None</span>
+                                    <span class="badge bg-primary text-primary-fg">{{ $role->name }}</span>
+                                @empty
+                                    <span class="text-muted">None</span>
                                 @endforelse
                             </div>
                         </div>
@@ -120,32 +128,34 @@
                         </div>
                     </div>
                 </div>
-                <div class="card-footer align-content-end d-flex btn-list">
-                    <a href="{{ route('admin.users.delete', $user->id) }}" class="btn btn-outline-danger">
-                        <i class="icon ti ti-trash"></i>
-                        Delete
-                    </a>
-                    <a href="{{ route('admin.users.impersonate', $user->id) }}"
-                       class="btn btn-primary-outline ms-auto">
-                        <i class="icon ti ti-spy"></i>
-                        Impersonate
-                    </a>
-                    <a href="{{ route('admin.users.sync', $user->id) }}"
-                       class="btn btn-primary-outline">
-                        <i class="icon ti ti-refresh"></i>
-                        Sync Tickets
-                    </a>
-                    <a href="{{ route('admin.tickets.index', ['user_id' => $user->id]) }}"
-                       class="btn btn-primary-outline">
-                        <i class="icon ti ti-ticket"></i>
-                        Tickets
-                        ({{ $user->tickets()->count() }})
-                    </a>
-                    <a href="{{ route('admin.users.edit', $user->id) }}" class="btn btn-primary">
-                        <i class="icon ti ti-edit"></i>
-                        Edit
-                    </a>
-                </div>
+                @can('admin')
+                    <div class="card-footer align-content-end d-flex btn-list">
+                        <a href="{{ route('admin.users.delete', $user->id) }}" class="btn btn-outline-danger">
+                            <i class="icon ti ti-trash"></i>
+                            Delete
+                        </a>
+                        <a href="{{ route('admin.users.impersonate', $user->id) }}"
+                           class="btn btn-primary-outline ms-auto">
+                            <i class="icon ti ti-spy"></i>
+                            Impersonate
+                        </a>
+                        <a href="{{ route('admin.users.sync', $user->id) }}"
+                           class="btn btn-primary-outline">
+                            <i class="icon ti ti-refresh"></i>
+                            Sync Tickets
+                        </a>
+                        <a href="{{ route('admin.tickets.index', ['user_id' => $user->id]) }}"
+                           class="btn btn-primary-outline">
+                            <i class="icon ti ti-ticket"></i>
+                            Tickets
+                            ({{ $user->tickets()->count() }})
+                        </a>
+                        <a href="{{ route('admin.users.edit', $user->id) }}" class="btn btn-primary">
+                            <i class="icon ti ti-edit"></i>
+                            Edit
+                        </a>
+                    </div>
+                @endcan
             </div>
         </div>
     </div>
@@ -162,8 +172,10 @@
                             <th>ID</th>
                             <th>Provider</th>
                             <th>Nickname</th>
-                            <th>External ID</th>
-                            <th></th>
+                            @can('admin')
+                                <th>External ID</th>
+                                <th></th>
+                            @endcan
                         </tr>
                         </thead>
                         <tbody>
@@ -177,20 +189,24 @@
                                               style="background-image: url('{{ $account->avatar_url }}')"></span>
                                         <div class="flex-fill">
                                             <div class="font-weight-medium">{{ $account->name }}</div>
-                                            <div class="text-secondary">{{ $account->email->email ?? '' }}</div>
+                                            @can('admin')
+                                                <div class="text-secondary">{{ $account->email->email ?? '' }}</div>
+                                            @endcan
                                         </div>
                                     </div>
                                 </td>
-                                <td>{{ $account->external_id }}</td>
-                                <td>
-                                    <div class="btn-list">
-                                        <a class="ms-auto btn btn-outline-danger @if(!$account->canDelete()) disabled @endif"
-                                           @if ($account->canDelete()) href="{{ route('admin.users.accounts.delete', [$user->id, $account->id]) }}" @endif>
-                                            <i class="icon ti ti-trash"></i>
-                                            Delete
-                                        </a>
-                                    </div>
-                                </td>
+                                @can('admin')
+                                    <td>{{ $account->external_id }}</td>
+                                    <td>
+                                        <div class="btn-list">
+                                            <a class="ms-auto btn btn-outline-danger @if(!$account->canDelete()) disabled @endif"
+                                               @if ($account->canDelete()) href="{{ route('admin.users.accounts.delete', [$user->id, $account->id]) }}" @endif>
+                                                <i class="icon ti ti-trash"></i>
+                                                Delete
+                                            </a>
+                                        </div>
+                                    </td>
+                                @endcan
                             </tr>
 
                         @empty
@@ -207,88 +223,89 @@
         </div>
     </div>
 
-
-    <div class="row align-items-center">
-        <div class="col page-header mt-2">
-            <h2>Email Addresses</h2>
-        </div>
-        <div class="col-auto ms-auto d-print-none">
-            <div class="btn-list">
-                <a href="{{ route('admin.users.emails.create', $user->id) }}" class="btn btn-primary d-inline-block">
-                    <i class="icon ti ti-mail-plus"></i>
-                    Add Email Address
-                </a>
+    @can('admin')
+        <div class="row align-items-center">
+            <div class="col page-header mt-2">
+                <h2>Email Addresses</h2>
             </div>
-        </div>
-    </div>
-
-    <div class="row mb-4">
-        <div class="col-12">
-            <div class="card">
-                <div class="table-responsive">
-                    <table class="table table-vcenter card-table">
-                        <thead>
-                        <tr>
-                            <th>ID</th>
-                            <th>Address</th>
-                            <th>Verified</th>
-                            <th>Linked Accounts</th>
-                            <th></th>
-                        </tr>
-                        </thead>
-                        <tbody>
-                        @forelse($user->emails as $email)
-                            <tr>
-                                <td class="text-muted">{{ $email->id }}</td>
-                                <td>
-                                    {{ $email->email }}
-                                    @if($email->id === $user->primaryEmail->id)
-                                        <i class="icon ti ti-star-filled text-yellow"></i>
-                                    @endif
-                                </td>
-                                <td>
-                                    @if($email->verified_at)
-                                        <span
-                                            title="{{ $email->verified_at->format('Y-m-d H:i:s') }}">{{ $email->verified_at->diffForHumans() }}</span>
-                                    @else
-                                        <span class="status status-red">No</span>
-                                    @endif
-                                </td>
-                                <td>
-                                    <span class="badges-list">
-                                        @foreach($email->linkedAccounts as $account)
-                                            <span
-                                                class="badge bg-{{ $account->provider->code }} text-{{ $account->provider->code }}-fg">{{ $account->provider->name }}</span>
-                                        @endforeach
-                                    </span>
-                                </td>
-                                <td class="btn-list">
-                                    <a class="btn btn-outline-primary ms-auto"
-                                       href="{{ route('admin.users.emails.edit', [$user->id, $email->id]) }}">
-                                        <i class="icon ti ti-edit"></i>
-                                        Edit
-                                    </a>
-                                    <a class="btn btn-outline-danger @if(!$email->canDelete()) disabled @endif"
-                                       @if ($email->canDelete()) href="{{ route('admin.users.emails.delete', [$user->id, $email->id]) }}" @endif>
-                                        <i class="icon ti ti-trash"></i>
-                                        Delete
-                                    </a>
-                                </td>
-                            </tr>
-
-                        @empty
-                            <tr>
-                                <td colspan="5" class="text-center p-4">
-                                    <p>There are no email addresses</p>
-                                </td>
-                            </tr>
-                        @endforelse
-                        </tbody>
-                    </table>
+            <div class="col-auto ms-auto d-print-none">
+                <div class="btn-list">
+                    <a href="{{ route('admin.users.emails.create', $user->id) }}" class="btn btn-primary d-inline-block">
+                        <i class="icon ti ti-mail-plus"></i>
+                        Add Email Address
+                    </a>
                 </div>
             </div>
         </div>
-    </div>
+
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="table-responsive">
+                        <table class="table table-vcenter card-table">
+                            <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Address</th>
+                                <th>Verified</th>
+                                <th>Linked Accounts</th>
+                                <th></th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @forelse($user->emails as $email)
+                                <tr>
+                                    <td class="text-muted">{{ $email->id }}</td>
+                                    <td>
+                                        {{ $email->email }}
+                                        @if($email->id === $user->primaryEmail->id)
+                                            <i class="icon ti ti-star-filled text-yellow"></i>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        @if($email->verified_at)
+                                            <span
+                                                title="{{ $email->verified_at->format('Y-m-d H:i:s') }}">{{ $email->verified_at->diffForHumans() }}</span>
+                                        @else
+                                            <span class="status status-red">No</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        <span class="badges-list">
+                                            @foreach($email->linkedAccounts as $account)
+                                                <span
+                                                    class="badge bg-{{ $account->provider->code }} text-{{ $account->provider->code }}-fg">{{ $account->provider->name }}</span>
+                                            @endforeach
+                                        </span>
+                                    </td>
+                                    <td class="btn-list">
+                                        <a class="btn btn-outline-primary ms-auto"
+                                           href="{{ route('admin.users.emails.edit', [$user->id, $email->id]) }}">
+                                            <i class="icon ti ti-edit"></i>
+                                            Edit
+                                        </a>
+                                        <a class="btn btn-outline-danger @if(!$email->canDelete()) disabled @endif"
+                                           @if ($email->canDelete()) href="{{ route('admin.users.emails.delete', [$user->id, $email->id]) }}" @endif>
+                                            <i class="icon ti ti-trash"></i>
+                                            Delete
+                                        </a>
+                                    </td>
+                                </tr>
+
+                            @empty
+                                <tr>
+                                    <td colspan="5" class="text-center p-4">
+                                        <p>There are no email addresses</p>
+                                    </td>
+                                </tr>
+                            @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endcan
 
     <h2>Clans</h2>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -90,7 +90,7 @@
                             </span>
                         </a>
                     </li>
-                    @can('admin')
+                    @canany(['admin', 'manager'])
                         <li class="nav-item dropdown @if(($activenav ?? null) === 'admin') active @endif">
                             <a class="nav-link dropdown-toggle  @if(($activenav ?? null) === 'admin') show @endif"
                                href="#navbar-admin" data-bs-toggle="dropdown" data-bs-auto-close="false" role="button">
@@ -107,11 +107,13 @@
                                 <a class="dropdown-item" href="{{ route('admin.users.index') }}">Users</a>
                                 <a class="dropdown-item" href="{{ route('admin.clans.index') }}">Clans</a>
                                 <a class="dropdown-item" href="{{ route('admin.events.index') }}">Events</a>
-                                <a class="dropdown-item" href="{{ route('admin.tickets.index') }}">Tickets</a>
-                                <a class="dropdown-item" href="{{ route('admin.settings.index') }}">Settings</a>
+                                @can('admin')
+                                    <a class="dropdown-item" href="{{ route('admin.tickets.index') }}">Tickets</a>
+                                    <a class="dropdown-item" href="{{ route('admin.settings.index') }}">Settings</a>
+                                @endcan
                             </div>
                         </li>
-                    @endcan
+                    @endcanany
                     <li class="nav-item">
                         <a class="nav-link" href="{{ route('logout') }}">
                         <span class="nav-link-icon d-md-none d-lg-inline-block">


### PR DESCRIPTION
Hopefully addresses #26 and #31

Added a lower-privileged manager role which has  access to limited administrative functionality. Users are still able to perform all the usual self-actions that any user can perform in addition to the following:

### Manager role permissions
- View admin dashboard
- Users
    - Can
        - View user list and user details
    - Cannot
        - See email addresses
        - See full names (truncated to first-names only) * See external entity IDs * Create/edit/update/delete
- Clans
    - Can
        - View clan list and clan details
    - Cannot
        -  See invite codes
        - Create/edit/update/delete
- Events
    - Can
        - View event list and basic event details (top container only)
        - Manage event seating (view seatmap and place/unplace seats)
    - Cannot
        - See seating plans
        - See ticket types * See ticket mappings * Create/edit/update/delete
- Tickets
    - No access
- Settings 
    - No access
- Seating Plans
    - Can
        - View draft event seating plans in the usual /seating endpoint 

### Requirements
- artisan db:seed