### PR TITLE
Seat Groups Implementation

### DIFF
--- a/_ide_helper_models.php
+++ b/_ide_helper_models.php
@@ -307,6 +307,7 @@ namespace App\Models{
  * @property string $label
  * @property string|null $description
  * @property string|null $class
+ *  @property int $seat_group_id
  * @property int $disabled
  * @property \Illuminate\Support\Carbon|null $created_at
  * @property \Illuminate\Support\Carbon|null $updated_at

--- a/app/Http/Controllers/Admin/EventController.php
+++ b/app/Http/Controllers/Admin/EventController.php
@@ -94,11 +94,13 @@ class EventController extends Controller
     public function show(Event $event)
     {
         $seatingPlans = $event->seatingPlans()->withCount('seats')->orderBy('order', 'ASC')->get();
+        $seatGroups = $event->seatGroups()->withCount('seats')->withCount('assignments')->get();
         $ticketTypes = $event->ticketTypes()->withCount('tickets')->get();
 
         return view('admin.events.show', [
             'event' => $event,
             'seatingPlans' => $seatingPlans,
+            'seatGroups' => $seatGroups,
             'ticketTypes' => $ticketTypes,
         ]);
     }

--- a/app/Http/Controllers/Admin/SeatController.php
+++ b/app/Http/Controllers/Admin/SeatController.php
@@ -39,6 +39,7 @@ class SeatController extends Controller
         $seat->label = $request->input('label');
         $seat->description = $request->input('description');
         $seat->class = $request->input('class');
+        $seat->seat_group_id = $request->input('seat_group');
         $seat->disabled = (bool)$request->input('disabled', false);
         $seat->save();
     }

--- a/app/Http/Controllers/Admin/SeatGroupAssignmentController.php
+++ b/app/Http/Controllers/Admin/SeatGroupAssignmentController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\DeleteRequest;
+use App\Http\Requests\Admin\SeatGroupAssignmentUpdateRequest;
+use App\Http\Requests\Admin\SeatGroupUpdateRequest;
+use App\Models\Event;
+use App\Models\SeatGroup;
+use App\Models\SeatGroupAssignment;
+use Illuminate\Http\Request;
+
+class SeatGroupAssignmentController extends Controller
+{
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create(Event $event, SeatGroup $seatgroup)
+    {
+        $assignment = new SeatGroupAssignment();
+        $assignment->group()->associate($seatgroup);
+        return view('admin.seatgroupassignments.create', [
+            'event' => $event,
+            'group' => $seatgroup
+        ]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(SeatGroupAssignmentUpdateRequest $request, Event $event, SeatGroup $seatgroup)
+    {
+        $assignment = new SeatGroupAssignment();
+        $assignment->group()->associate($seatgroup);
+        $this->updateObject($assignment, $request);
+        return response()->redirectToRoute('admin.events.seatgroups.show', [$event->code, $seatgroup->id])->with('successMessage', 'The seat group assignment has been created');
+    }
+
+    protected function updateObject(SeatGroupAssignment $assignment, Request $request)
+    {
+        $assignment->assignment_type = $request->input('assignment_type');
+        $assignment->assignment_type_id = $request->input('assignment_type_id');
+        $assignment->save();
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Event $event, SeatGroup $seatgroup, SeatGroupAssignment $assignment)
+    {
+        return view('admin.seatgroupassignments.edit', [
+            'event' => $event,
+            'group' => $seatgroup,
+            'assignment' => $assignment
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(SeatGroupAssignmentUpdateRequest $request, Event $event, SeatGroup $seatgroup, SeatGroupAssignment $assignment)
+    {
+        $this->updateObject($assignment, $request);
+        return response()->redirectToRoute('admin.events.seatgroups.show', [$event->code, $seatgroup->id]);
+    }
+
+    public function destroy(DeleteRequest $request, Event $event, SeatGroup $seatgroup, SeatGroupAssignment $assignment)
+    {
+        $assignment->delete();
+        return response()->redirectToRoute('admin.events.seatgroups.show', [$event->code, $seatgroup->id]);
+    }
+
+    public function delete(Event $event, SeatGroup $seatgroup, SeatGroupAssignment $assignment)
+    {
+        return view('admin.seatgroupassignments.delete', [
+            'event' => $event,
+            'group' => $seatgroup,
+            'assignment' => $assignment,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/SeatGroupController.php
+++ b/app/Http/Controllers/Admin/SeatGroupController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Admin\DeleteRequest;
+use App\Http\Requests\Admin\SeatGroupUpdateRequest;
+use App\Models\Event;
+use App\Models\Seat;
+use App\Models\SeatGroup;
+use Illuminate\Http\Request;
+
+class SeatGroupController extends Controller
+{
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create(Event $event)
+    {
+        $group = new SeatGroup();
+        $group->event()->associate($event);
+        return view('admin.seatgroups.create', [
+            'event' => $event
+        ]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(SeatGroupUpdateRequest $request, Event $event)
+    {
+        $group = new SeatGroup();
+        $group->event()->associate($event);
+        $this->updateObject($group, $request);
+        return response()->redirectToRoute('admin.events.seatgroups.show', [$event->code, $group->id])->with('successMessage', 'The seat group has been created');
+    }
+
+    protected function updateObject(SeatGroup $group, Request $request)
+    {
+        $group->name = $request->input('name');
+        $group->class = $request->input('class');
+        $group->save();
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Event $event, SeatGroup $seatgroup)
+    {
+        return view('admin.seatgroups.show', [
+            'event' => $event,
+            'group' => $seatgroup
+        ]);
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Event $event, SeatGroup $seatgroup)
+    {
+        return view('admin.seatgroups.edit', [
+            'event' => $event,
+            'group' => $seatgroup
+        ]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(SeatGroupUpdateRequest $request, Event $event, SeatGroup $seatgroup)
+    {
+        $this->updateObject($seatgroup, $request);
+        return response()->redirectToRoute('admin.events.seatgroups.show', [$event->code, $seatgroup->id]);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(DeleteRequest $request, Event $event, SeatGroup $seatgroup)
+    {
+        $seatgroup->delete();
+        return response()->redirectToRoute('admin.events.show', $event->code);
+    }
+
+    public function delete(Event $event, SeatGroup $seatgroup)
+    {
+        return view('admin.seatgroups.delete', [
+            'event' => $event,
+            'group' => $seatgroup,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/SeatingPlanController.php
+++ b/app/Http/Controllers/Admin/SeatingPlanController.php
@@ -99,7 +99,7 @@ class SeatingPlanController extends Controller
     public function export(Event $event, SeatingPlan $seatingplan)
     {
         $csv = [[
-            'ID', 'X', 'Y', 'Row', 'Number', 'Label', 'Description', 'CSS Class', 'Disabled',
+            'ID', 'X', 'Y', 'Row', 'Number', 'Label', 'Description', 'CSS Class', 'Seat Group ID', 'Disabled',
         ]];
         $seatingplan->seats()->chunk(100, function ($chunk) use (&$csv) {
             foreach ($chunk as $seat) {
@@ -112,6 +112,7 @@ class SeatingPlanController extends Controller
                     $seat->label,
                     $seat->description,
                     $seat->class,
+                    $seat->group ? $seat->group->id : null,
                     $seat->disabled ? 1 : 0,
                 ];
             }

--- a/app/Http/Controllers/Admin/SeatingPlanController.php
+++ b/app/Http/Controllers/Admin/SeatingPlanController.php
@@ -35,8 +35,11 @@ class SeatingPlanController extends Controller
     {
         $plan->name = $request->input('name');
         $plan->image_url = $request->input('image_url');
-        $plan->image_height = getimagesize($request->input('image_url'))[1];
-        $plan->image_width = getimagesize($request->input('image_url'))[0];
+        $imageSizeArr = getimagesize($request->input('image_url'));
+        if($imageSizeArr) {
+            $plan->image_height = $imageSizeArr[1];
+            $plan->image_width = $imageSizeArr[0];
+        }
         $plan->scale = $request->input('scale') ? $request->input('scale') : 100;
         $plan->save();
     }

--- a/app/Http/Controllers/SeatingPlanController.php
+++ b/app/Http/Controllers/SeatingPlanController.php
@@ -101,7 +101,7 @@ class SeatingPlanController extends Controller
 
         $seatGroups = [];
         foreach ($event->seatGroups as $seatGroup) {
-            if($request->user()->allowedSeatGroup($seatGroup)) {
+            if ($currentTicket->user->allowedSeatGroup($seatGroup)) {
                 array_push($seatGroups, $seatGroup->id);
             }
         }
@@ -148,7 +148,7 @@ class SeatingPlanController extends Controller
             return response()->redirectToRoute('seatingplans.show', $event->code)->with('errorMessage', 'You cannot pick a seat for this ticket')->withFragment("tab-plan-{$seat->plan->code}");
         }
 
-        if (!$seat->canPick($request->user())) {
+        if (!$seat->canPick($ticket->user)) {
             return response()->redirectToRoute('seatingplans.show', [$event->code, $ticket->id])->with('errorMessage', "That seat is not available")->withFragment("tab-plan-{$seat->plan->code}");
         }
 

--- a/app/Http/Controllers/SeatingPlanController.php
+++ b/app/Http/Controllers/SeatingPlanController.php
@@ -99,6 +99,13 @@ class SeatingPlanController extends Controller
             $seats[$plan->id] = $plan->getData();
         }
 
+        $seatGroups = [];
+        foreach ($event->seatGroups as $seatGroup) {
+            if($request->user()->allowedSeatGroup($seatGroup)) {
+                array_push($seatGroups, $seatGroup->id);
+            }
+        }
+
         $params = [
             'allTickets' => $allTickets,
             'event' => $event,
@@ -108,6 +115,7 @@ class SeatingPlanController extends Controller
             'responsibleSeats' => $responsibleSeats,
             'responsibleTickets' => $responsibleTickets,
             'currentTicket' => $currentTicket,
+            'seatGroups' => $seatGroups
         ];
 
         $view = 'seatingplans.show';

--- a/app/Http/Controllers/SeatingPlanController.php
+++ b/app/Http/Controllers/SeatingPlanController.php
@@ -100,9 +100,11 @@ class SeatingPlanController extends Controller
         }
 
         $seatGroups = [];
-        foreach ($event->seatGroups as $seatGroup) {
-            if ($currentTicket->user->allowedSeatGroup($seatGroup)) {
-                array_push($seatGroups, $seatGroup->id);
+        if ($currentTicket) {
+            foreach ($event->seatGroups as $seatGroup) {
+                if ($currentTicket->user->allowedSeatGroup($seatGroup)) {
+                    array_push($seatGroups, $seatGroup->id);
+                }
             }
         }
 

--- a/app/Http/Requests/Admin/SeatGroupAssignmentUpdateRequest.php
+++ b/app/Http/Requests/Admin/SeatGroupAssignmentUpdateRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class SeatGroupAssignmentUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $assignmentType = $this->input('assignment_type');
+        return [
+            'assignment_type' => 'required',
+            'assignment_type_id' => 'required|integer|exists:'.$assignmentType.'s,id',
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/SeatGroupUpdateRequest.php
+++ b/app/Http/Requests/Admin/SeatGroupUpdateRequest.php
@@ -5,7 +5,7 @@ namespace App\Http\Requests\Admin;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
-class SeatUpdateRequest extends FormRequest
+class SeatGroupUpdateRequest extends FormRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -23,15 +23,8 @@ class SeatUpdateRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'x' => 'required|integer|min:0',
-            'y' => 'required|integer|min:0',
-            'row' => 'required|string|max:8',
-            'number' => 'required|integer|min:0',
-            'label' => 'required|string|max:100',
-            'description' => 'sometimes|string|nullable|max:255',
+            'name' => 'required|string|max:100',
             'class' => 'sometimes|string|nullable|max:255',
-            'seat_group' => 'sometimes|exists:seat_groups,id|nullable',
-            'disabled' => 'sometimes|boolean|nullable',
         ];
     }
 }

--- a/app/Models/Clan.php
+++ b/app/Models/Clan.php
@@ -10,7 +10,27 @@ use InvalidArgumentException;
 use function App\makeCode;
 
 /**
+ * App\Models\Clan
+ *
  * @mixin IdeHelperClan
+ * @property int $id
+ * @property string $name
+ * @property string $code
+ * @property string $invite_code
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\ClanMembership> $members
+ * @property-read int|null $members_count
+ * @method static \Illuminate\Database\Eloquent\Builder|Clan newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Clan newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Clan query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Clan whereCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Clan whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Clan whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Clan whereInviteCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Clan whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Clan whereUpdatedAt($value)
+ * @mixin \Eloquent
  */
 class Clan extends Model
 {

--- a/app/Models/ClanMembership.php
+++ b/app/Models/ClanMembership.php
@@ -8,7 +8,28 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
+ * App\Models\ClanMembership
+ *
  * @mixin IdeHelperClanMembership
+ * @property int $id
+ * @property int $user_id
+ * @property int $clan_id
+ * @property int $clan_role_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Clan $clan
+ * @property-read \App\Models\ClanRole $role
+ * @property-read \App\Models\User $user
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanMembership newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanMembership newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanMembership query()
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanMembership whereClanId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanMembership whereClanRoleId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanMembership whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanMembership whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanMembership whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanMembership whereUserId($value)
+ * @mixin \Eloquent
  */
 class ClanMembership extends Model
 {

--- a/app/Models/ClanRole.php
+++ b/app/Models/ClanRole.php
@@ -8,7 +8,25 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
+ * App\Models\ClanRole
+ *
  * @mixin IdeHelperClanRole
+ * @property int $id
+ * @property string $code
+ * @property string $name
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\ClanMembership> $members
+ * @property-read int|null $members_count
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanRole newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanRole newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanRole query()
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanRole whereCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanRole whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanRole whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanRole whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|ClanRole whereUpdatedAt($value)
+ * @mixin \Eloquent
  */
 class ClanRole extends Model
 {

--- a/app/Models/EmailAddress.php
+++ b/app/Models/EmailAddress.php
@@ -15,7 +15,32 @@ use Illuminate\Support\Facades\Mail;
 use function App\makeCode;
 
 /**
+ * App\Models\EmailAddress
+ *
  * @mixin IdeHelperEmailAddress
+ * @property int $id
+ * @property int $user_id
+ * @property string $email
+ * @property string|null $verification_code
+ * @property \Illuminate\Support\Carbon|null $verification_sent_at
+ * @property \Illuminate\Support\Carbon|null $verified_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\LinkedAccount> $linkedAccounts
+ * @property-read int|null $linked_accounts_count
+ * @property-read \App\Models\User $user
+ * @method static \Illuminate\Database\Eloquent\Builder|EmailAddress newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|EmailAddress newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|EmailAddress query()
+ * @method static \Illuminate\Database\Eloquent\Builder|EmailAddress whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EmailAddress whereEmail($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EmailAddress whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EmailAddress whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EmailAddress whereUserId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EmailAddress whereVerificationCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EmailAddress whereVerificationSentAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EmailAddress whereVerifiedAt($value)
+ * @mixin \Eloquent
  */
 class EmailAddress extends Model
 {

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -8,7 +8,47 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
+ * App\Models\Event
+ *
  * @mixin IdeHelperEvent
+ * @property int $id
+ * @property string $name
+ * @property string $code
+ * @property int $draft
+ * @property string|null $boxoffice_url
+ * @property \Illuminate\Support\Carbon|null $starts_at
+ * @property \Illuminate\Support\Carbon|null $ends_at
+ * @property int $seating_locked
+ * @property \Illuminate\Support\Carbon|null $seating_opens_at
+ * @property \Illuminate\Support\Carbon|null $seating_closes_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\EventMapping> $mappings
+ * @property-read int|null $mappings_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\SeatGroup> $seatGroups
+ * @property-read int|null $seat_groups_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\SeatingPlan> $seatingPlans
+ * @property-read int|null $seating_plans_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\TicketType> $ticketTypes
+ * @property-read int|null $ticket_types_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Ticket> $tickets
+ * @property-read int|null $tickets_count
+ * @method static \Illuminate\Database\Eloquent\Builder|Event newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Event newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Event query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereBoxofficeUrl($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereDraft($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereEndsAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereSeatingClosesAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereSeatingLocked($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereSeatingOpensAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereStartsAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Event whereUpdatedAt($value)
+ * @mixin \Eloquent
  */
 class Event extends Model
 {
@@ -44,6 +84,11 @@ class Event extends Model
     public function seatingPlans(): HasMany
     {
         return $this->hasMany(SeatingPlan::class);
+    }
+
+    public function seatGroups(): HasMany
+    {
+        return $this->hasMany(SeatGroup::class);
     }
 
     public function getAvailableEventMappings(?EventMapping $existing = null): array

--- a/app/Models/EventMapping.php
+++ b/app/Models/EventMapping.php
@@ -8,7 +8,29 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
+ * App\Models\EventMapping
+ *
  * @mixin IdeHelperEventMapping
+ * @property int $id
+ * @property int $event_id
+ * @property int $ticket_provider_id
+ * @property string $external_id
+ * @property string|null $name
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Event $event
+ * @property-read \App\Models\TicketProvider $provider
+ * @method static \Illuminate\Database\Eloquent\Builder|EventMapping newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|EventMapping newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|EventMapping query()
+ * @method static \Illuminate\Database\Eloquent\Builder|EventMapping whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EventMapping whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EventMapping whereExternalId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EventMapping whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EventMapping whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EventMapping whereTicketProviderId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|EventMapping whereUpdatedAt($value)
+ * @mixin \Eloquent
  */
 class EventMapping extends Model
 {

--- a/app/Models/LinkedAccount.php
+++ b/app/Models/LinkedAccount.php
@@ -8,7 +8,40 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
+ * App\Models\LinkedAccount
+ *
  * @mixin IdeHelperLinkedAccount
+ * @property int $id
+ * @property int $user_id
+ * @property int|null $email_address_id
+ * @property int|null $social_provider_id
+ * @property string|null $external_id
+ * @property string|null $name
+ * @property string|null $avatar_url
+ * @property mixed|null $access_token
+ * @property mixed|null $refresh_token
+ * @property string|null $access_token_expires_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\EmailAddress|null $email
+ * @property-read \App\Models\SocialProvider|null $provider
+ * @property-read \App\Models\User $user
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount query()
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereAccessToken($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereAccessTokenExpiresAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereAvatarUrl($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereEmailAddressId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereExternalId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereRefreshToken($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereSocialProviderId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|LinkedAccount whereUserId($value)
+ * @mixin \Eloquent
  */
 class LinkedAccount extends Model
 {

--- a/app/Models/ProviderSetting.php
+++ b/app/Models/ProviderSetting.php
@@ -12,7 +12,41 @@ use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
 
 /**
+ * App\Models\ProviderSetting
+ *
  * @mixin IdeHelperProviderSetting
+ * @property int $id
+ * @property string $provider_type
+ * @property int $provider_id
+ * @property string $name
+ * @property string $code
+ * @property string|null $description
+ * @property SettingType $type
+ * @property int $encrypted
+ * @property string|null $validation
+ * @property mixed|null|null $value
+ * @property int $order
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read Model|\Eloquent $provider
+ * @method static Builder|ProviderSetting newModelQuery()
+ * @method static Builder|ProviderSetting newQuery()
+ * @method static Builder|ProviderSetting ordered(string $direction = 'asc')
+ * @method static Builder|ProviderSetting query()
+ * @method static Builder|ProviderSetting whereCode($value)
+ * @method static Builder|ProviderSetting whereCreatedAt($value)
+ * @method static Builder|ProviderSetting whereDescription($value)
+ * @method static Builder|ProviderSetting whereEncrypted($value)
+ * @method static Builder|ProviderSetting whereId($value)
+ * @method static Builder|ProviderSetting whereName($value)
+ * @method static Builder|ProviderSetting whereOrder($value)
+ * @method static Builder|ProviderSetting whereProviderId($value)
+ * @method static Builder|ProviderSetting whereProviderType($value)
+ * @method static Builder|ProviderSetting whereType($value)
+ * @method static Builder|ProviderSetting whereUpdatedAt($value)
+ * @method static Builder|ProviderSetting whereValidation($value)
+ * @method static Builder|ProviderSetting whereValue($value)
+ * @mixin \Eloquent
  */
 class ProviderSetting extends Model implements Sortable
 {

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -8,7 +8,25 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
+ * App\Models\Role
+ *
  * @mixin IdeHelperRole
+ * @property int $id
+ * @property string $code
+ * @property string $name
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> $users
+ * @property-read int|null $users_count
+ * @method static \Illuminate\Database\Eloquent\Builder|Role newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Role newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Role query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Role whereCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Role whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Role whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Role whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Role whereUpdatedAt($value)
+ * @mixin \Eloquent
  */
 class Role extends Model
 {

--- a/app/Models/Seat.php
+++ b/app/Models/Seat.php
@@ -6,9 +6,47 @@ use App\Models\Traits\ToString;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Collection;
 
 /**
+ * App\Models\Seat
+ *
  * @mixin IdeHelperSeat
+ * @property int $id
+ * @property int $seating_plan_id
+ * @property int|null $seat_group_id
+ * @property int|null $ticket_id
+ * @property int $x
+ * @property int $y
+ * @property string $row
+ * @property int $number
+ * @property string $label
+ * @property string|null $description
+ * @property string|null $class
+ * @property int $disabled
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\SeatGroup|null $group
+ * @property-read \App\Models\SeatingPlan $plan
+ * @property-read \App\Models\Ticket|null $ticket
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereClass($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereDisabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereLabel($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereNumber($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereRow($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereSeatGroupId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereSeatingPlanId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereTicketId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereX($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Seat whereY($value)
+ * @mixin \Eloquent
  */
 class Seat extends Model
 {
@@ -22,6 +60,11 @@ class Seat extends Model
     public function plan(): BelongsTo
     {
         return $this->belongsTo(SeatingPlan::class, 'seating_plan_id');
+    }
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(SeatGroup::class, 'seat_group_id');
     }
 
     public function canPick(?User $user = null): bool
@@ -39,13 +82,18 @@ class Seat extends Model
         if (!$tickets) {
             return false;
         }
+        if($this->group) {
+            if(!$user->allowedSeatGroup($this->group)) {
+                return false;
+            }
+        }
         if ($this->ticket) {
             foreach ($tickets as $ticket) {
                 if ($ticket->id === $this->ticket->id) {
-                    return true;
+                   return true;
                 }
+                return false;
             }
-            return false;
         }
         return true;
     }

--- a/app/Models/SeatGroup.php
+++ b/app/Models/SeatGroup.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Traits\ToString;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * App\Models\SeatGroup
+ *
+ * @property int $id
+ * @property string $name
+ * @property int $event_id
+ * @property string|null $class
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\SeatGroupAssignment> $assignments
+ * @property-read int|null $assignments_count
+ * @property-read \App\Models\Event $event
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Seat> $seats
+ * @property-read int|null $seats_count
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroup newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroup newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroup query()
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroup whereClass($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroup whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroup whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroup whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroup whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroup whereUpdatedAt($value)
+ * @mixin \Eloquent
+ */
+class SeatGroup extends Model
+{
+    use HasFactory, ToString;
+
+    public function event(): BelongsTo
+    {
+        return $this->belongsTo(Event::class);
+    }
+
+    public function assignments(): HasMany
+    {
+        return $this->hasMany(SeatGroupAssignment::class);
+    }
+
+    public function seats(): HasMany
+    {
+        return $this->hasMany(Seat::class);
+    }
+}

--- a/app/Models/SeatGroupAssignment.php
+++ b/app/Models/SeatGroupAssignment.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+/**
+ * App\Models\SeatGroupAssignment
+ *
+ * @property int $id
+ * @property int $seat_group_id
+ * @property string $assignment_type
+ * @property int $assignment_type_id
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\SeatGroup|null $group
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroupAssignment newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroupAssignment newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroupAssignment query()
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroupAssignment whereAssignmentType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroupAssignment whereAssignmentTypeId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroupAssignment whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroupAssignment whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroupAssignment whereSeatGroupId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SeatGroupAssignment whereUpdatedAt($value)
+ * @mixin \Eloquent
+ */
+class SeatGroupAssignment extends Model
+{
+    use HasFactory;
+
+    public function group(): BelongsTo
+    {
+        return $this->belongsTo(SeatGroup::class, 'seat_group_id');
+    }
+}

--- a/app/Models/SeatingPlan.php
+++ b/app/Models/SeatingPlan.php
@@ -172,6 +172,7 @@ class SeatingPlan extends Model implements Sortable
                 $seat->label = $row[5];
                 $seat->description = $row[6] ?? null;
                 $seat->class = $row[7] ?? null;
+                $seat->seat_group_id = (int)$row[8] ?? null;
                 $seat->disabled = (bool)$row[8];
 
                 $seat->saveQuietly();

--- a/app/Models/SeatingPlan.php
+++ b/app/Models/SeatingPlan.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -17,7 +18,41 @@ use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
 
 /**
+ * App\Models\SeatingPlan
+ *
  * @mixin IdeHelperSeatingPlan
+ * @property int $id
+ * @property int $event_id
+ * @property string $name
+ * @property string $code
+ * @property int $order
+ * @property int $scale
+ * @property int $revision
+ * @property string|null $image_url
+ * @property int|null $image_height
+ * @property int|null $image_width
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Event $event
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Seat> $seats
+ * @property-read int|null $seats_count
+ * @method static Builder|SeatingPlan newModelQuery()
+ * @method static Builder|SeatingPlan newQuery()
+ * @method static Builder|SeatingPlan ordered(string $direction = 'asc')
+ * @method static Builder|SeatingPlan query()
+ * @method static Builder|SeatingPlan whereCode($value)
+ * @method static Builder|SeatingPlan whereCreatedAt($value)
+ * @method static Builder|SeatingPlan whereEventId($value)
+ * @method static Builder|SeatingPlan whereId($value)
+ * @method static Builder|SeatingPlan whereImageHeight($value)
+ * @method static Builder|SeatingPlan whereImageUrl($value)
+ * @method static Builder|SeatingPlan whereImageWidth($value)
+ * @method static Builder|SeatingPlan whereName($value)
+ * @method static Builder|SeatingPlan whereOrder($value)
+ * @method static Builder|SeatingPlan whereRevision($value)
+ * @method static Builder|SeatingPlan whereScale($value)
+ * @method static Builder|SeatingPlan whereUpdatedAt($value)
+ * @mixin \Eloquent
  */
 class SeatingPlan extends Model implements Sortable
 {
@@ -58,7 +93,7 @@ class SeatingPlan extends Model implements Sortable
         }
 
         $seats = $this->seats()
-            ->with(['ticket', 'ticket.user', 'plan', 'ticket.user.clanMemberships.clan'])
+            ->with(['ticket', 'ticket.user', 'plan', 'ticket.user.clanMemberships.clan', 'group.assignments'])
             ->orderBy('row', 'ASC')
             ->orderBy('number', 'ASC')
             ->get();
@@ -73,11 +108,12 @@ class SeatingPlan extends Model implements Sortable
                 'id' => $seat->id,
                 'x' => $seat->x,
                 'y' => $seat->y,
-                'class' => $seat->class,
+                'class' => $seat->group ? $seat->group->class : $seat->class,
                 'label' => $seat->label,
                 'row' => $seat->row,
                 'number' => $seat->number,
                 'disabled' => $seat->disabled,
+                'group' => $seat->group ? $seat->group->id : null,
                 'description' => $seat->description,
                 'nickname' => $seat->ticket->user->nickname ?? null,
                 'original_email' => $seat->ticket->original_email ?? null,

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -14,7 +14,38 @@ use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
 
 /**
+ * App\Models\Setting
+ *
  * @mixin IdeHelperSetting
+ * @property int $id
+ * @property string $code
+ * @property string $name
+ * @property string|null $description
+ * @property int $encrypted
+ * @property int $hidden
+ * @property mixed|null|null $value
+ * @property string|null $validation
+ * @property SettingType $type
+ * @property int $order
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting ordered(string $direction = 'asc')
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereDescription($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereEncrypted($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereHidden($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereOrder($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereType($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereValidation($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Setting whereValue($value)
+ * @mixin \Eloquent
  */
 class Setting extends Model implements Sortable
 {

--- a/app/Models/SocialProvider.php
+++ b/app/Models/SocialProvider.php
@@ -10,7 +10,37 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 
 /**
+ * App\Models\SocialProvider
+ *
  * @mixin IdeHelperSocialProvider
+ * @property int $id
+ * @property string $name
+ * @property string $code
+ * @property string $provider_class
+ * @property int $supports_auth
+ * @property int $enabled
+ * @property int $auth_enabled
+ * @property int $can_be_renamed
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\LinkedAccount> $accounts
+ * @property-read int|null $accounts_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\ProviderSetting> $settings
+ * @property-read int|null $settings_count
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider query()
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider whereAuthEnabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider whereCanBeRenamed($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider whereCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider whereEnabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider whereProviderClass($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider whereSupportsAuth($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|SocialProvider whereUpdatedAt($value)
+ * @mixin \Eloquent
  */
 class SocialProvider extends Model
 {

--- a/app/Models/Theme.php
+++ b/app/Models/Theme.php
@@ -6,7 +6,45 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 /**
+ * App\Models\Theme
+ *
  * @mixin IdeHelperTheme
+ * @property int $id
+ * @property string $name
+ * @property string $code
+ * @property int $readonly
+ * @property int $active
+ * @property int $dark_mode
+ * @property string $primary
+ * @property string $nav_background
+ * @property string $seat_available
+ * @property string $seat_disabled
+ * @property string $seat_taken
+ * @property string $seat_clan
+ * @property string $seat_selected
+ * @property string|null $css
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereActive($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereCss($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereDarkMode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereNavBackground($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme wherePrimary($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereReadonly($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereSeatAvailable($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereSeatClan($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereSeatDisabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereSeatSelected($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereSeatTaken($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Theme whereUpdatedAt($value)
+ * @mixin \Eloquent
  */
 class Theme extends Model
 {

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -13,7 +13,44 @@ use Illuminate\Support\Facades\DB;
 use function App\makeCode;
 
 /**
+ * App\Models\Ticket
+ *
  * @mixin IdeHelperTicket
+ * @property int $id
+ * @property int $ticket_provider_id
+ * @property int|null $user_id
+ * @property int $event_id
+ * @property int $ticket_type_id
+ * @property string $external_id
+ * @property string|null $original_email
+ * @property string $name
+ * @property string $reference
+ * @property string|null $qrcode
+ * @property string|null $transfer_code
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Event $event
+ * @property-read \App\Models\TicketProvider $provider
+ * @property-read \App\Models\Seat|null $seat
+ * @property-read \App\Models\TicketType $type
+ * @property-read \App\Models\User|null $user
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket query()
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereExternalId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereOriginalEmail($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereQrcode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereReference($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereTicketProviderId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereTicketTypeId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereTransferCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|Ticket whereUserId($value)
+ * @mixin \Eloquent
  */
 class Ticket extends Model
 {

--- a/app/Models/TicketProvider.php
+++ b/app/Models/TicketProvider.php
@@ -11,7 +11,37 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Http\Request;
 
 /**
+ * App\Models\TicketProvider
+ *
  * @mixin IdeHelperTicketProvider
+ * @property int $id
+ * @property string $name
+ * @property string $code
+ * @property string $provider_class
+ * @property int $enabled
+ * @property string $cache_prefix
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\EventMapping> $events
+ * @property-read int|null $events_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\ProviderSetting> $settings
+ * @property-read int|null $settings_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Ticket> $tickets
+ * @property-read int|null $tickets_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\TicketTypeMapping> $types
+ * @property-read int|null $types_count
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketProvider newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketProvider newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketProvider query()
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketProvider whereCachePrefix($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketProvider whereCode($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketProvider whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketProvider whereEnabled($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketProvider whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketProvider whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketProvider whereProviderClass($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketProvider whereUpdatedAt($value)
+ * @mixin \Eloquent
  */
 class TicketProvider extends Model
 {

--- a/app/Models/TicketType.php
+++ b/app/Models/TicketType.php
@@ -11,7 +11,34 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\Artisan;
 
 /**
+ * App\Models\TicketType
+ *
  * @mixin IdeHelperTicketType
+ * @property int $id
+ * @property int $event_id
+ * @property string $name
+ * @property int $has_seat
+ * @property string|null $discord_role_id
+ * @property string|null $discord_role_name
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\Event $event
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\TicketTypeMapping> $mappings
+ * @property-read int|null $mappings_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Ticket> $tickets
+ * @property-read int|null $tickets_count
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketType newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketType newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketType query()
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketType whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketType whereDiscordRoleId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketType whereDiscordRoleName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketType whereEventId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketType whereHasSeat($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketType whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketType whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketType whereUpdatedAt($value)
+ * @mixin \Eloquent
  */
 class TicketType extends Model
 {

--- a/app/Models/TicketTypeMapping.php
+++ b/app/Models/TicketTypeMapping.php
@@ -8,7 +8,29 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
+ * App\Models\TicketTypeMapping
+ *
  * @mixin IdeHelperTicketTypeMapping
+ * @property int $id
+ * @property int $ticket_type_id
+ * @property int $ticket_provider_id
+ * @property string $external_id
+ * @property string|null $name
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property-read \App\Models\TicketProvider $provider
+ * @property-read \App\Models\TicketType $type
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketTypeMapping newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketTypeMapping newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketTypeMapping query()
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketTypeMapping whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketTypeMapping whereExternalId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketTypeMapping whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketTypeMapping whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketTypeMapping whereTicketProviderId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketTypeMapping whereTicketTypeId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|TicketTypeMapping whereUpdatedAt($value)
+ * @mixin \Eloquent
  */
 class TicketTypeMapping extends Model
 {

--- a/database/migrations/2024_09_04_154938_add_scale_and_sizing_to_seating_plans.php
+++ b/database/migrations/2024_09_04_154938_add_scale_and_sizing_to_seating_plans.php
@@ -21,9 +21,12 @@ return new class extends Migration
         foreach (SeatingPlan::all() as $plan) {
             if ($plan->image_url)
             {
-                $plan->image_height = getimagesize($plan->image_url)[1];
-                $plan->image_width =  getimagesize($plan->image_url)[0];
-                $plan->save();
+                $imageSizeArr = getimagesize($plan->image_url);
+                if($imageSizeArr) {
+                    $plan->image_height = $imageSizeArr[1];
+                    $plan->image_width = $imageSizeArr[0];
+                    $plan->save();
+                }
             }
         }
     }

--- a/database/migrations/2024_09_06_135311_create_seat_groups_tables.php
+++ b/database/migrations/2024_09_06_135311_create_seat_groups_tables.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('seat_groups', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->integer('event_id');
+            $table->string('class')->nullable();
+            $table->timestamps();
+        });
+        Schema::create('seat_group_assignments', function (Blueprint $table) {
+            $table->id();
+            $table->integer('seat_group_id');
+            $table->string('assignment_type'); //'ticket_type' / 'clan' / 'user'
+            $table->integer('assignment_type_id'); // id of above object
+            $table->timestamps();
+        });
+        Schema::table('seats', function (Blueprint $table) {
+            $table->integer('seat_group_id')->nullable()->after('seating_plan_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('seat_groups');
+        Schema::dropIfExists('seat_group_assignments');
+        Schema::table('seats', function (Blueprint $table) {
+            $table->dropColumn('seat_group_id');
+        });
+    }
+};

--- a/resources/views/admin/events/seats.blade.php
+++ b/resources/views/admin/events/seats.blade.php
@@ -154,7 +154,7 @@
                                             } elseif ($seat->ticketId) {
                                                 $link = route('admin.events.seats', ['event' => $event->code, 'ticket_id' => $seat->ticketId]);
                                             }
-                                            $class = 'available';
+                                            $seat->class ? $class = $seat->class : $class = 'available';
                                             $name = 'Available';
                                             if ($seat->disabled) {
                                                 $class = 'disabled';
@@ -183,7 +183,7 @@
                                                 $tooltipContents .= '</span>';
                                             }
                                         @endphp
-                                        <a class="d-block seat {{ $seat->class }} {{ $class }}"
+                                        <a class="d-block seat {{ $class }}"
                                            @if($link)
                                                href="{{ $link }}"
                                            @endif

--- a/resources/views/admin/events/seats.blade.php
+++ b/resources/views/admin/events/seats.blade.php
@@ -154,7 +154,7 @@
                                             } elseif ($seat->ticketId) {
                                                 $link = route('admin.events.seats', ['event' => $event->code, 'ticket_id' => $seat->ticketId]);
                                             }
-                                            $seat->class ? $class = $seat->class : $class = 'available';
+                                            $class = 'available';
                                             $name = 'Available';
                                             if ($seat->disabled) {
                                                 $class = 'disabled';
@@ -183,7 +183,7 @@
                                                 $tooltipContents .= '</span>';
                                             }
                                         @endphp
-                                        <a class="d-block seat {{ $class }}"
+                                    <a class="d-block seat {{ $seat->class }} {{ $class }}"
                                            @if($link)
                                                href="{{ $link }}"
                                            @endif

--- a/resources/views/admin/events/show.blade.php
+++ b/resources/views/admin/events/show.blade.php
@@ -226,6 +226,64 @@
 
         <div class="row align-items-center">
             <div class="col page-header mt-2">
+                <h2>Seat Groups</h2>
+            </div>
+            <div class="col-auto ms-auto d-print-none">
+                <div class="btn-list">
+                    <a href="{{ route('admin.events.seatgroups.create', $event->code) }}"
+                       class="btn btn-primary d-inline-block">
+                        <i class="icon ti ti-plus"></i>
+                        Add Seat Group
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <p>
+            This is where you can define seat groups. Seat groups allow you to restrict the picking of seats to an individual user,
+            ticket type or clan.
+        </p>
+
+        <div class="row mb-4">
+            <div class="col-12">
+                <div class="card">
+                    <div class="table-responsive">
+                        <table class="table table-vcenter card-table">
+                            <thead>
+                            <tr>
+                                <th>ID</th>
+                                <th>Name</th>
+                                <th>Seats</th>
+                                <th>Assignments</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            @forelse($seatGroups as $group)
+                                <tr>
+                                    <td class="text-muted">{{ $group->id }}</td>
+                                    <td>
+                                        <a href="{{ route('admin.events.seatgroups.show', [$event->code, $group->id]) }}">{{ $group->name }}</a>
+                                    </td>
+                                    <td>{{ $group->seats_count }}</td>
+                                    <td>{{ $group->assignments_count }}</td>
+                                </tr>
+
+                            @empty
+                                <tr>
+                                    <td colspan="4" class="text-center p-4">
+                                        <p>There are no seat groups</p>
+                                    </td>
+                                </tr>
+                            @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row align-items-center">
+            <div class="col page-header mt-2">
                 <h2>Ticket Types</h2>
             </div>
             <div class="col-auto ms-auto d-print-none">

--- a/resources/views/admin/seatgroupassignments/_breadcrumbs.blade.php
+++ b/resources/views/admin/seatgroupassignments/_breadcrumbs.blade.php
@@ -1,0 +1,5 @@
+@include('admin.events._breadcrumbs', [
+    'active' => false,
+])
+<li class="breadcrumb-item @if($active ?? false) active @endif"><a
+        href="{{ route('admin.events.seatgroups.show', [$event->code, $group->id]) }}">{{ $group->name }}</a></li>

--- a/resources/views/admin/seatgroupassignments/_form.blade.php
+++ b/resources/views/admin/seatgroupassignments/_form.blade.php
@@ -1,0 +1,21 @@
+<div class="card-body">
+    <div class="mb-3">
+        <label class="form-label required">Assignment Type</label>
+        <select class="form-control" name="assignment_type">
+            <option value="user" selected>User</option>
+            <option value="clan">Clan</option>
+            <option value="ticket_type">Ticket Type</option>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label class="form-label required">Type ID</label>
+        <div>
+            <input type="text" name="assignment_type_id" class="form-control @error('assignment_type_id') is-invalid @enderror"
+                   placeholder="0" value="{{ old('name', $assignment->assignment_type_id ?? '') }}">
+            <small class="form-hint">The ID for the selected assignment type</small>
+            @error('assignment_type_id')
+                <p class="invalid-feedback">{{ $message }}</p>
+            @enderror
+        </div>
+    </div>
+</div>

--- a/resources/views/admin/seatgroupassignments/create.blade.php
+++ b/resources/views/admin/seatgroupassignments/create.blade.php
@@ -1,0 +1,26 @@
+@extends('layouts.app', [
+    'activenav' => 'admin',
+])
+
+@section('breadcrumbs')
+    @include('admin.seatgroupassignments._breadcrumbs')
+    <li class="breadcrumb-item active"><a href="{{ route('admin.events.seatgroups.assignments.create', [$event->code, $group->id]) }}">Add Seat Group</a></li>
+@endsection
+
+@section('content')
+    <div class="page-header mt-0">
+        <h1>Add Seat Group Assignment</h1>
+    </div>
+    <div class="col-md-6 offset-md-3">
+        <form action="{{ route('admin.events.seatgroups.assignments.store', [$event->code, $group->id]) }}" method="post" class="card">
+            {{ csrf_field() }}
+            @include('admin.seatgroupassignments._form')
+            <div class="card-footer text-end">
+                <div class="d-flex">
+                    <a href="{{ route('admin.events.seatgroups.show', [$event->code, $group->id]) }}" class="btn btn-link">Cancel</a>
+                    <button type="submit" class="btn btn-primary ms-auto">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/admin/seatgroupassignments/delete.blade.php
+++ b/resources/views/admin/seatgroupassignments/delete.blade.php
@@ -1,0 +1,47 @@
+@extends('layouts.app', [
+    'activenav' => 'admin',
+])
+
+@section('breadcrumbs')
+    @include('admin.seatgroupassignments._breadcrumbs')
+        @endsection
+
+        @section('content')
+            <div class="page-header mt-0">
+                <h1>Delete Assignment {{ $assignment->id }}</h1>
+            </div>
+
+            <div class="col-md-6 offset-md-3">
+                <form action="{{ route('admin.events.seatgroups.assignments.destroy', [$event->code, $group->id, $assignment->id]) }}" method="post"
+                      class="card">
+                    <div class="card-status-top bg-danger"></div>
+                    {{ csrf_field() }}
+                    {{ method_field('DELETE') }}
+                    <div class="card-body text-center">
+                        <i class="icon mb-4 ti ti-alert-triangle icon-lg text-danger"></i>
+                        <p class="mt-4">
+                            Are you sure you want to delete <strong>{{ $assignment->name }}</strong> for {{ $group->name }}?
+                        </p>
+                        <p>
+                            To continue, please type 'delete' in the box below.
+                        </p>
+                        <div class="mb-3 col-md-6 offset-md-3">
+                            <div>
+                                <input type="text" name="confirm"
+                                       class="form-control @error('confirm') is-invalid @enderror" placeholder="delete">
+                                @error('confirm')
+                                    <p class="invalid-feedback">{{ $message }}</p>
+                                @enderror
+                            </div>
+                        </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <div class="d-flex">
+                            <a href="{{ route('admin.events.seatgroups.show', [$event->code, $group->id]) }}"
+                               class="btn btn-link">Cancel</a>
+                            <button type="submit" class="btn btn-danger ms-auto">Delete</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+@endsection

--- a/resources/views/admin/seatgroupassignments/edit.blade.php
+++ b/resources/views/admin/seatgroupassignments/edit.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.app', [
+    'activenav' => 'admin',
+])
+
+@section('breadcrumbs')
+    @include('admin.seatgroupassignments._breadcrumbs')
+    <li class="breadcrumb-item active"><a
+            href="{{ route('admin.events.seatgroups.assignments.edit', [$event->code, $group->id, $assignment->id]) }}">
+            Edit Mapping</a></li>
+@endsection
+
+@section('content')
+    <div class="page-header mt-0">
+        <h1>Edit Seat Group Assignment</h1>
+    </div>
+
+    <div class="col-md-6 offset-md-3">
+        <form action="{{ route('admin.events.seatgroups.assignments.update', [$event->code, $group->id, $assignment->id]) }}"
+              method="post" class="card">
+            {{ csrf_field() }}
+            {{ method_field('PATCH') }}
+            @include('admin.seatgroupassignments._form')
+            <div class="card-footer text-end">
+                <div class="d-flex">
+                    <a href="{{ route('admin.events.seatgroups.show', [$event->code, $group->id]) }}"
+                       class="btn btn-link">Cancel</a>
+                    <button type="submit" class="btn btn-primary ms-auto">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/admin/seatgroups/_breadcrumbs.blade.php
+++ b/resources/views/admin/seatgroups/_breadcrumbs.blade.php
@@ -1,0 +1,5 @@
+@include('admin.events._breadcrumbs', [
+    'active' => false,
+])
+<li class="breadcrumb-item @if($active ?? false) active @endif"><a
+        href="{{ route('admin.events.seatgroups.show', [$event->code, $group->id]) }}">{{ $group->name }}</a></li>

--- a/resources/views/admin/seatgroups/_form.blade.php
+++ b/resources/views/admin/seatgroups/_form.blade.php
@@ -1,0 +1,24 @@
+<div class="card-body">
+    <div class="mb-3">
+        <label class="form-label required">Name</label>
+        <div>
+            <input type="text" name="name" class="form-control @error('name') is-invalid @enderror"
+                   placeholder="Name" value="{{ old('name', $group->name ?? '') }}">
+            <small class="form-hint">The name of the seat group</small>
+            @error('name')
+            <p class="invalid-feedback">{{ $message }}</p>
+            @enderror
+        </div>
+    </div>
+    <div class="mb-3">
+        <label class="form-label">CSS Class</label>
+        <div>
+            <input type="text" name="class" class="form-control @error('class') is-invalid @enderror"
+                   placeholder="my-class" value="{{ old('class', $group->class ?? '') }}">
+            <small class="form-hint">An optional CSS class to apply to this seat group assignment</small>
+            @error('class')
+            <p class="invalid-feedback">{{ $message }}</p>
+            @enderror
+        </div>
+    </div>
+</div>

--- a/resources/views/admin/seatgroups/create.blade.php
+++ b/resources/views/admin/seatgroups/create.blade.php
@@ -1,0 +1,27 @@
+@extends('layouts.app', [
+    'activenav' => 'admin',
+])
+
+@section('breadcrumbs')
+    @include('admin.events._breadcrumbs')
+    <li class="breadcrumb-item active"><a href="{{ route('admin.events.seatgroups.create', $event->code) }}">Add Seat Group</a></li>
+@endsection
+
+@section('content')
+    <div class="page-header mt-0">
+        <h1>Add Seat Group</h1>
+    </div>
+
+    <div class="col-md-6 offset-md-3">
+        <form action="{{ route('admin.events.seatgroups.store', $event->code) }}" method="post" class="card">
+            {{ csrf_field() }}
+            @include('admin.seatgroups._form')
+            <div class="card-footer text-end">
+                <div class="d-flex">
+                    <a href="{{ route('admin.events.show', $event->code) }}" class="btn btn-link">Cancel</a>
+                    <button type="submit" class="btn btn-primary ms-auto">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/admin/seatgroups/delete.blade.php
+++ b/resources/views/admin/seatgroups/delete.blade.php
@@ -1,0 +1,49 @@
+@extends('layouts.app', [
+    'activenav' => 'admin',
+])
+
+@section('breadcrumbs')
+    @include('admin.seatgroups._breadcrumbs')
+    <li class="breadcrumb-item active"><a
+            href="{{ route('admin.events.seatgroups.delete', [$event->code, $group->id]) }}">Delete</a>
+        @endsection
+
+        @section('content')
+            <div class="page-header mt-0">
+                <h1>Delete {{ $group->name }}</h1>
+            </div>
+
+            <div class="col-md-6 offset-md-3">
+                <form action="{{ route('admin.events.seatgroups.destroy', [$event->code, $group->id]) }}" method="post"
+                      class="card">
+                    <div class="card-status-top bg-danger"></div>
+                    {{ csrf_field() }}
+                    {{ method_field('DELETE') }}
+                    <div class="card-body text-center">
+                        <i class="icon mb-4 ti ti-alert-triangle icon-lg text-danger"></i>
+                        <p class="mt-4">
+                            Are you sure you want to delete <strong>{{ $group->name }}</strong> for {{ $event->name }}?
+                        </p>
+                        <p>
+                            To continue, please type 'delete' in the box below.
+                        </p>
+                        <div class="mb-3 col-md-6 offset-md-3">
+                            <div>
+                                <input type="text" name="confirm"
+                                       class="form-control @error('confirm') is-invalid @enderror" placeholder="delete">
+                                @error('confirm')
+                                <p class="invalid-feedback">{{ $message }}</p>
+                                @enderror
+                            </div>
+                        </div>
+                    </div>
+                    <div class="card-footer text-end">
+                        <div class="d-flex">
+                            <a href="{{ route('admin.events.seatgroups.show', [$event->code, $group->id]) }}"
+                               class="btn btn-link">Cancel</a>
+                            <button type="submit" class="btn btn-danger ms-auto">Delete</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+@endsection

--- a/resources/views/admin/seatgroups/edit.blade.php
+++ b/resources/views/admin/seatgroups/edit.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.app', [
+    'activenav' => 'admin',
+])
+
+@section('breadcrumbs')
+    @include('admin.seatgroups._breadcrumbs')
+    <li class="breadcrumb-item active"><a
+            href="{{ route('admin.events.seatgroups.edit', [$event->code, $group->id]) }}">Edit</a></li>
+@endsection
+
+@section('content')
+    <div class="page-header mt-0">
+        <h1>Edit {{ $group->name }}</h1>
+    </div>
+
+    <div class="col-md-6 offset-md-3">
+        <form action="{{ route('admin.events.seatgroups.update', [$event->code, $group->id]) }}" method="post"
+              class="card">
+            {{ csrf_field() }}
+            {{ method_field('PATCH') }}
+            @include('admin.seatgroups._form')
+            <div class="card-footer text-end">
+                <div class="d-flex">
+                    <a href="{{ route('admin.events.seatgroups.show', [$event->code, $group->id]) }}"
+                       class="btn btn-link">Cancel</a>
+                    <button type="submit" class="btn btn-primary ms-auto">Save</button>
+                </div>
+            </div>
+        </form>
+    </div>
+@endsection

--- a/resources/views/admin/seatgroups/show.blade.php
+++ b/resources/views/admin/seatgroups/show.blade.php
@@ -1,0 +1,129 @@
+@extends('layouts.app', [
+    'activenav' => 'admin',
+])
+
+@section('breadcrumbs')
+    @include('admin.seatgroupassignments._breadcrumbs', [
+        'active' => true,
+    ])
+@endsection
+
+@section('content')
+    <div class="page-header mt-0">
+        <h1>{{ $group->name }}</h1>
+    </div>
+
+    <div class="row mb-4">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-body">
+                    <div class="datagrid">
+                        <div class="datagrid-item">
+                            <div class="datagrid-title">ID</div>
+                            <div class="datagrid-content">{{ $group->id }}</div>
+                        </div>
+                        <div class="datagrid-item">
+                            <div class="datagrid-title">Name</div>
+                            <div class="datagrid-content">{{ $group->name }}</div>
+                        </div>
+                        <div class="datagrid-item">
+                            <div class="datagrid-title">Seats</div>
+                            <div class="datagrid-content">{{ $group->seats->count() }}</div>
+                        </div>
+                        <div class="datagrid-item">
+                            <div class="datagrid-title">Event</div>
+                            <div class="datagrid-content">
+                                <a href="{{ route('admin.events.show', $event->code) }}">{{ $event->name }}</a>
+                            </div>
+                        </div>
+                        @if($group->class)
+                            <div class="datagrid-item">
+                                <div class="datagrid-title">CSS Class</div>
+                                <div class="datagrid-content">{{ $group->class }}</div>
+                            </div>
+                        @endif
+                    </div>
+                </div>
+                <div class="card-footer align-content-end d-flex btn-list">
+                    <a href="{{ route('admin.events.seatgroups.delete', [$event->code, $group->id]) }}"
+                       class="btn btn-outline-danger">
+                        <i class="icon ti ti-trash"></i>
+                        Delete
+                    </a>
+                    <a href="{{ route('admin.events.seatgroups.edit', [$event->code, $group->id]) }}"
+                       class="btn btn-primary">
+                        <i class="icon ti ti-edit"></i>
+                        Edit
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row align-items-center">
+        <div class="col page-header mt-2">
+            <h2>Seat Group Assignments</h2>
+        </div>
+        <div class="col-auto ms-auto d-print-none">
+            <div class="btn-list">
+                <a href="{{ route('admin.events.seatgroups.assignments.create', [$event->code, $group->id]) }}"
+                   class="btn btn-primary d-inline-block">
+                    <i class="icon ti ti-plus"></i>
+                    Add Assignment
+                </a>
+            </div>
+        </div>
+    </div>
+
+    <p>
+        Assignments allow you to define the constraints for this seat group, multiple of these are treated as an OR condition.
+    </p>
+
+    <div class="row mb-4">
+        <div class="col-12">
+            <div class="card">
+                <div class="table-responsive">
+                    <table class="table table-vcenter card-table">
+                        <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Assignment Type</th>
+                            <th>Assignment Type ID</th>
+                            <th></th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @forelse($group->assignments as $assignment)
+                            <tr>
+                                <td class="text-muted">{{ $assignment->id }}</td>
+                                <td>{{ $assignment->assignment_type }}</td>
+                                <td>{{ $assignment->assignment_type_id }}</td>
+
+                                <td class="btn-list">
+                                    <a class="btn btn-outline-primary ms-auto"
+                                       href="{{ route('admin.events.seatgroups.assignments.edit', [$event->code, $group->id, $assignment->id]) }}">
+                                        <i class="icon ti ti-edit"></i>
+                                        Edit
+                                    </a>
+                                    <a class="btn btn-outline-danger"
+                                       href="{{ route('admin.events.seatgroups.assignments.delete', [$event->code, $group->id, $assignment->id]) }}">
+                                        <i class="icon ti ti-trash"></i>
+                                        Delete
+                                    </a>
+                                </td>
+                            </tr>
+
+                        @empty
+                            <tr>
+                                <td colspan="4" class="text-center p-4">
+                                    <p>There are no seat group assignments</p>
+                                </td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/seatgroups/show.blade.php
+++ b/resources/views/admin/seatgroups/show.blade.php
@@ -96,8 +96,27 @@
                         @forelse($group->assignments as $assignment)
                             <tr>
                                 <td class="text-muted">{{ $assignment->id }}</td>
-                                <td>{{ $assignment->assignment_type }}</td>
-                                <td>{{ $assignment->assignment_type_id }}</td>
+                                <td>{{ ucwords(str_replace('_', ' ', $assignment->assignment_type)) }}</td>
+                                <td>
+                                    @switch($assignment->assignment_type)
+                                        @case('user')
+                                            <a href="{{ route('admin.users.show', $assignment->assignment_type_id) }}">
+                                                {{ \App\Models\User::find($assignment->assignment_type_id)->nickname }}
+                                            </a>
+                                            @break
+                                        @case('clan')
+                                            @php($clan = \App\Models\Clan::find($assignment->assignment_type_id))
+                                            <a href="{{ route('admin.clans.show', $clan->code) }}">
+                                                {{ $clan->name }}
+                                            </a>
+                                            @break
+                                        @case('ticket_type')
+                                            <a href="{{ route('admin.events.tickettypes.show', [$assignment->group->event->code, $assignment->assignment_type_id]) }}">
+                                                {{ \App\Models\TicketType::find($assignment->assignment_type_id)->name }}
+                                            </a>
+                                            @break
+                                    @endswitch
+                                </td>
 
                                 <td class="btn-list">
                                     <a class="btn btn-outline-primary ms-auto"

--- a/resources/views/admin/seatingplans/import.blade.php
+++ b/resources/views/admin/seatingplans/import.blade.php
@@ -26,10 +26,10 @@
                     optional header row. If it is detected, it will be ignored.
                 </p>
                 <p>An example format would be:</p>
-                <pre><code>ID,X,Y,Row,Number,Label,Description,CSS Class,Disabled
-1,2,22,A,1,A1,,,0
-2,3,22,A,2,A2,,,0
-3,4,22,A,3,A3,,,0
+                <pre><code>ID,X,Y,Row,Number,Label,Description,CSS Class,Seat Group ID,Disabled
+1,2,22,A,1,A1,,1,0
+2,3,22,A,2,A2,,2,0
+3,4,22,A,3,A3,,,1
 4,5,22,A,4,A4,,,0</code></pre>
                 <p>
                     If the ID field is included for a seat, then an existing seat with that ID in the plan will be

--- a/resources/views/admin/seatingplans/show.blade.php
+++ b/resources/views/admin/seatingplans/show.blade.php
@@ -131,7 +131,7 @@
                     >
                         @foreach($seats as $seat)
                             @php
-                                $class = 'available';
+                                $seat->class ? $class = $seat->class : $class = 'available';
                                 $name = 'Available';
                                 if ($seat->disabled) {
                                     $class = 'disabled';
@@ -153,7 +153,7 @@
                                     $tooltipContents .= '</span>';
                                 }
                             @endphp
-                            <a class="d-block seat {{ $seat->class }} {{ $class }}"
+                            <a class="d-block seat {{ $class }}"
                                href="{{ route('admin.events.seatingplans.seats.show', [$event->code, $plan->id, $seat->id]) }}"
                                style="left: {{ $seat->x * 0.02 * $plan->scale }}em; top: {{ $seat->y * 0.02 * $plan->scale }}em; width: {{ 0.019 * $plan->scale }}em; height: {{ 0.019 * $plan->scale }}em;"
                                data-bs-trigger="hover" data-bs-toggle="popover"

--- a/resources/views/admin/seatingplans/show.blade.php
+++ b/resources/views/admin/seatingplans/show.blade.php
@@ -131,7 +131,7 @@
                     >
                         @foreach($seats as $seat)
                             @php
-                                $seat->class ? $class = $seat->class : $class = 'available';
+                                $class = 'available';
                                 $name = 'Available';
                                 if ($seat->disabled) {
                                     $class = 'disabled';
@@ -153,7 +153,7 @@
                                     $tooltipContents .= '</span>';
                                 }
                             @endphp
-                            <a class="d-block seat {{ $class }}"
+                        <a class="d-block seat {{ $seat->class }} {{ $class }}"
                                href="{{ route('admin.events.seatingplans.seats.show', [$event->code, $plan->id, $seat->id]) }}"
                                style="left: {{ $seat->x * 0.02 * $plan->scale }}em; top: {{ $seat->y * 0.02 * $plan->scale }}em; width: {{ 0.019 * $plan->scale }}em; height: {{ 0.019 * $plan->scale }}em;"
                                data-bs-trigger="hover" data-bs-toggle="popover"

--- a/resources/views/admin/seats/_form.blade.php
+++ b/resources/views/admin/seats/_form.blade.php
@@ -81,6 +81,17 @@
         </div>
     </div>
     <div class="mb-3">
+        <label class="form-label">Seat Group ID</label>
+        <div>
+            <input type="text" name="seat_group" class="form-control @error('seat_group') is-invalid @enderror"
+                   placeholder="1" value="{{ old('seat_group', $seat->seat_group_id ?? '') }}">
+            <small class="form-hint">Add seat to seat group</small>
+            @error('seat_group')
+            <p class="invalid-feedback">{{ $message }}</p>
+            @enderror
+        </div>
+    </div>
+    <div class="mb-3">
         <label class="form-check form-switch">
             <input type="checkbox" class="form-check-input" name="disabled" value="1"
                    @if(old('disabled', $seat->disabled)) checked @endif>

--- a/resources/views/admin/seats/show.blade.php
+++ b/resources/views/admin/seats/show.blade.php
@@ -74,7 +74,11 @@
                         </div>
                         <div class="datagrid-item">
                             <div class="datagrid-title">Seat Group</div>
-                            <div class="datagrid-content">{{ $seat->group ? $seat->group->id : '' }}</div>
+                            @if ($seat->group)
+                                <div class="datagrid-content"><a href="{{ route('admin.events.seatgroups.show', [$seat->plan->event->code, $seat->group->id]) }}">{{ $seat->group->id }}</a></div>
+                            @else
+                                <span class="text-muted">None</span>
+                            @endif
                         </div>
                     </div>
                 </div>

--- a/resources/views/admin/seats/show.blade.php
+++ b/resources/views/admin/seats/show.blade.php
@@ -72,6 +72,10 @@
                                 @endif
                             </div>
                         </div>
+                        <div class="datagrid-item">
+                            <div class="datagrid-title">Seat Group</div>
+                            <div class="datagrid-content">{{ $seat->group ? $seat->group->id : '' }}</div>
+                        </div>
                     </div>
                 </div>
                 <div class="card-footer align-content-end d-flex btn-list">

--- a/resources/views/seatingplans/_plan.blade.php
+++ b/resources/views/seatingplans/_plan.blade.php
@@ -30,6 +30,9 @@
                     if(!in_array($seat->group, $seatGroups)) {
                         $canPick = false;
                         $name = 'Not Available';
+                        if ($class === 'available') {
+                            $class = 'disabled';
+                        }
                     }
                 }
                 if ($seat->nickname) {

--- a/resources/views/seatingplans/_plan.blade.php
+++ b/resources/views/seatingplans/_plan.blade.php
@@ -14,7 +14,7 @@
                 if ($currentTicket) {
                     $url = route('seatingplans.select', [$event->code, $currentTicket->id, $seat->id]);
                 }
-                $class = 'available';
+                $seat->class ? $class = $seat->class : $class = 'available';
                 $name = 'Available';
                 $canPick = $seat->canPick;
                 if ($seat->disabled) {
@@ -25,6 +25,12 @@
                     $class = 'taken';
                     $canPick = false;
                     $name = 'Occupied';
+                }
+                if($seat->group) {
+                    if(!in_array($seat->group, $seatGroups)) {
+                        $canPick = false;
+                        $name = 'Not Available';
+                    }
                 }
                 if ($seat->nickname) {
                     $name = $seat->nickname;
@@ -55,7 +61,7 @@
                 }
 
             @endphp
-            <{{ $canPick ? 'a' : 'div' }} class="d-block seat {{ $seat->class }} {{ $class }}"
+            <{{ $canPick ? 'a' : 'div' }} class="d-block seat {{ $class }}"
             @if($canPick)
                 href="{{ $url }}"
             @endif

--- a/resources/views/seatingplans/_plan.blade.php
+++ b/resources/views/seatingplans/_plan.blade.php
@@ -14,7 +14,7 @@
                 if ($currentTicket) {
                     $url = route('seatingplans.select', [$event->code, $currentTicket->id, $seat->id]);
                 }
-                $seat->class ? $class = $seat->class : $class = 'available';
+                $class = 'available';
                 $name = 'Available';
                 $canPick = $seat->canPick;
                 if ($seat->disabled) {
@@ -61,7 +61,7 @@
                 }
 
             @endphp
-            <{{ $canPick ? 'a' : 'div' }} class="d-block seat {{ $class }}"
+        <{{ $canPick ? 'a' : 'div' }} class="d-block seat {{ $seat->class }} {{ $class }}"
             @if($canPick)
                 href="{{ $url }}"
             @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\Admin\EventMappingController;
 use App\Http\Controllers\Admin\HomeController as AdminHomeController;
 use App\Http\Controllers\Admin\LinkedAccountController as AdminLinkedAccountController;
 use App\Http\Controllers\Admin\SeatController as AdminSeatController;
+use App\Http\Controllers\Admin\SeatGroupController;
+use App\Http\Controllers\Admin\SeatGroupAssignmentController;
 use App\Http\Controllers\Admin\SeatingPlanController as AdminSeatingPlanController;
 use App\Http\Controllers\Admin\SettingController as AdminSettingController;
 use App\Http\Controllers\Admin\SocialProviderController;
@@ -135,6 +137,11 @@ Route::middleware('auth:sanctum')->group(function () {
                 Route::resource('events.seatingplans.seats', AdminSeatController::class)->except(['index'])->scoped();
                 Route::get('events/{event}/seatingplans/{seatingplan}/seats/{seat}/delete', [AdminSeatController::class, 'delete'])->name('events.seatingplans.seats.delete')->scopeBindings();
                 Route::get('events/{event}/seatingplans/{seatingplan}/seats/{seat}/unseat', [AdminSeatController::class, 'unseat'])->name('events.seatingplans.seats.unseat')->scopeBindings();
+
+                Route::resource('events.seatgroups', SeatGroupController::class)->except(['index'])->scoped();
+                Route::get('events/{event}/seatgroups/{seatgroup}/delete', [SeatGroupController::class, 'delete'])->name('events.seatgroups.delete')->scopeBindings();
+                Route::resource('events.seatgroups.assignments', SeatGroupAssignmentController::class)->except(['show', 'index'])->scoped();
+                Route::get('/events/{event}/seatgroups/{seatgroup}/assignments/{assignment}/delete', [SeatGroupAssignmentController::class, 'delete'])->name('events.seatgroups.assignments.delete')->scopeBindings();
 
                 Route::resource('events.tickettypes', TicketTypeController::class)->except(['index'])->scoped();
                 Route::get('events/{event}/tickettypes/{tickettype}/delete', [TicketTypeController::class, 'delete'])->name('events.tickettypes.delete')->scopeBindings();


### PR DESCRIPTION
Added seating groups to events.

Seat groups can be set on an event, and then assignments can be made to each group by either user, ticket_type or clan - multiple can be set and will be treated as an OR condition.

Looking to address #7 with this.