### PR TITLE
Fix to seatplan CSS

### DIFF
--- a/resources/views/seatingplans/_plan.blade.php
+++ b/resources/views/seatingplans/_plan.blade.php
@@ -31,7 +31,7 @@
                         $canPick = false;
                         $name = 'Not Available';
                         if ($class === 'available') {
-                            $class = 'disabled';
+                            $class = '';
                         }
                     }
                 }


### PR DESCRIPTION
When a group style is in-use but the user doesnt have permissions to the seat, it will show greyed out as disabled, this will maintain the group coloring instead.