### PR TITLE
Update Dockerfile to reduce attack surface

### DIFF
--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -16,12 +16,15 @@ RUN composer install \
         --ignore-platform-reqs
 
 # Use the node23 image to do an npm install
-FROM node:23 AS npm
+FROM node:23-slim AS npm
 
 WORKDIR /app/
 ENV HOME=/tmp
 RUN mkdir -p /app
 COPY --from=composer /app/ /app
+
+# Update npm to the latest version to patch vulnerabilities
+RUN npm install -g npm@latest
 
 RUN npm install --production=false && \
     npm run build


### PR DESCRIPTION
Hello,

Don't know yet whether you do need the full Node.JS package or whether the Slim one would do, but just in case, here is a PR to switch to Node 23 slim:

- Node 23 has 13 high vulnerabilities.
- Switching to Node 23-slim will reduce the attack surface down to 1 high vuln.
- Also adds a line to the docker image to update npm if needed to mitigate resolution with further updates to npm.

Feel free to discard if not useful.