### PR TITLE
Preselect ticket when choosing seat from home

### DIFF
--- a/resources/views/home/home.blade.php
+++ b/resources/views/home/home.blade.php
@@ -41,7 +41,7 @@
                                     </td>
                                     <td>
                                         @if ($ticket->canPickSeat())
-                                            <a href="{{ route('seatingplans.show', $ticket->event->code) }}">
+                                            <a href="{{ route('seatingplans.show', $ticket->event->code, $ticket) }}">
                                                 {{ $ticket->seat->label ?? 'Choose Seat' }}
                                             </a>
                                         @else


### PR DESCRIPTION
Passes through the ticket reference so that the ticket is selected when the seating plan is loaded. This will then make all the available seats clear.